### PR TITLE
fix: strip quarantine metadata from release artifacts

### DIFF
--- a/Scripts/package-app.sh
+++ b/Scripts/package-app.sh
@@ -25,6 +25,19 @@ cleanup() {
 }
 trap cleanup EXIT
 
+strip_quarantine_metadata() {
+  xattr -cr "$@"
+}
+
+assert_no_quarantine_metadata() {
+  local path="$1"
+
+  if xattr -lr "$path" | grep -q 'com\.apple\.quarantine'; then
+    printf '%s\n' "quarantine metadata remains in $path; refusing to package a release artifact that asks users to run xattr manually." >&2
+    exit 1
+  fi
+}
+
 cd "$ROOT"
 swift build -c release
 rm -rf "$ROOT/dist"
@@ -99,6 +112,8 @@ clang \
   -o "$SAVER_MACOS_DIR/$SAVER_EXECUTABLE"
 chmod +x "$MACOS_DIR/Workshop Wallpaper Bridge" "$MACOS_DIR/wwbctl"
 chmod +x "$SAVER_MACOS_DIR/$SAVER_EXECUTABLE"
+strip_quarantine_metadata "$APP_DIR"
+assert_no_quarantine_metadata "$APP_DIR"
 if [ -n "$SIGN_IDENTITY" ]; then
   codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$MACOS_DIR/wwbctl"
   codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$MACOS_DIR/Workshop Wallpaper Bridge"
@@ -114,12 +129,16 @@ fi
 DMG_STAGING="$(mktemp -d)"
 cp -R "$APP_DIR" "$DMG_STAGING/"
 ln -s /Applications "$DMG_STAGING/Applications"
+strip_quarantine_metadata "$DMG_STAGING/$APP_NAME.app"
+assert_no_quarantine_metadata "$DMG_STAGING/$APP_NAME.app"
 hdiutil create \
   -volname "$APP_NAME" \
   -srcfolder "$DMG_STAGING" \
   -ov \
   -format UDZO \
   "$DMG_PATH" >/dev/null
+strip_quarantine_metadata "$DMG_PATH"
+assert_no_quarantine_metadata "$DMG_PATH"
 if [ -n "$SIGN_IDENTITY" ]; then
   codesign --force --timestamp --sign "$SIGN_IDENTITY" "$DMG_PATH"
   codesign --verify --verbose=2 "$DMG_PATH"

--- a/Scripts/package-app.sh
+++ b/Scripts/package-app.sh
@@ -31,8 +31,14 @@ strip_quarantine_metadata() {
 
 assert_no_quarantine_metadata() {
   local path="$1"
+  local xattrs
 
-  if xattr -lr "$path" | grep -q 'com\.apple\.quarantine'; then
+  if ! xattrs="$(xattr -lr "$path" 2>/dev/null)"; then
+    printf '%s\n' "failed to read extended attributes from $path" >&2
+    exit 1
+  fi
+
+  if grep -q 'com\.apple\.quarantine' <<<"$xattrs"; then
     printf '%s\n' "quarantine metadata remains in $path; refusing to package a release artifact that asks users to run xattr manually." >&2
     exit 1
   fi

--- a/Scripts/package-app.sh
+++ b/Scripts/package-app.sh
@@ -26,7 +26,19 @@ cleanup() {
 trap cleanup EXIT
 
 strip_quarantine_metadata() {
-  xattr -cr "$@"
+  local path
+  local xattrs
+
+  for path in "$@"; do
+    if ! xattrs="$(xattr -lr "$path" 2>/dev/null)"; then
+      printf '%s\n' "failed to read extended attributes from $path" >&2
+      exit 1
+    fi
+
+    if grep -q 'com\.apple\.quarantine' <<<"$xattrs"; then
+      xattr -r -d com.apple.quarantine "$path"
+    fi
+  done
 }
 
 assert_no_quarantine_metadata() {


### PR DESCRIPTION
## Summary
- Reopened and addresses #1, where the latest macOS release still opened as a damaged app until users manually ran `xattr -cr`.
- Strip quarantine extended attributes from the generated app bundle, the DMG staging copy, and the final DMG during packaging.
- Fail packaging if `com.apple.quarantine` remains, so a release artifact cannot silently ship with the metadata that triggers the manual workaround.

## Why
The issue thread showed the current release could still require users to remove quarantine metadata by hand after installation. Release packaging should do that cleanup before publishing the DMG, and it should verify the result instead of relying on users to discover the workaround.

## Validation
- `bash -n Scripts/package-app.sh`
- `swift test`
- `bash Scripts/package-app.sh`
- `xattr -lr "dist/Workshop Wallpaper Bridge.app" "dist/WorkshopWallpaperBridge-macOS-arm64.dmg" | grep -q "com\.apple\.quarantine"` exits cleanly with no quarantine metadata found

Closes #1