### PR TITLE
fix: prevent app switch wallpaper flicker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,40 @@ Before proposing or committing changes, check:
 - Are unsupported Wallpaper Engine runtime features still described honestly?
 - Did README changes update both English and Korean docs when user-facing behavior changed?
 
+## Open Source Workflow For AI Agents
+
+Treat this repository like a public open-source project, even for local agent work.
+
+- Do not commit directly to `main` unless the user explicitly asks for a direct hotfix.
+- Create a focused branch before publishing changes, for example `fix/dock-flicker` or `docs/contribution-workflow`.
+- Keep each branch and pull request scoped to one problem.
+- Use Conventional Commit messages from this file.
+- Before opening a PR, run the required local checks for the touched surface:
+  - `swift test` for code changes.
+  - `bash Scripts/package-app.sh` for app bundle or release changes.
+  - `swift run wwbctl doctor` for CLI behavior changes.
+- Open a GitHub pull request with a short summary, test evidence, and any AI assistance note when an assistant materially shaped the change.
+- Do not merge a PR until the local checks are green and the diff has been reviewed.
+
+## Patch And Release Workflow
+
+When preparing a patch release:
+
+1. Start from an up-to-date `main`.
+2. Create a branch named for the fix, such as `fix/<issue-slug>`.
+3. Make the smallest behavior-preserving patch that solves the issue.
+4. Add or update regression tests before the production fix when behavior changes.
+5. Run `swift test` and, for app releases, `bash Scripts/package-app.sh`.
+6. Commit with a `fix:` subject for bug fixes.
+7. Push the branch and open a PR.
+8. Merge the PR into `main`.
+9. Tag the merged commit with the next semantic version:
+   - Patch bug fix: `vMAJOR.MINOR.PATCH`
+   - Feature release: `vMAJOR.MINOR.0`
+10. Push the tag. The release workflow builds the DMG, checksum, and GitHub Release.
+
+Release tags must use the `v<version>` format because `.github/workflows/release.yml` derives the app version from the tag.
+
 ## Commit Messages
 
 Use this convention:
@@ -83,4 +117,3 @@ revert: 내용
 ```
 
 Why this exists: consistent commits make open-source review and release history easier to scan.
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,4 +12,5 @@ Quick reminders:
 - Run `swift test` before saying a code change is complete.
 - Update both `README.md` and `README.ko.md` for user-facing behavior changes.
 - Use the commit convention documented in `CONTRIBUTING.md`.
-
+- Work like an open-source contributor: create a focused branch, commit with a Conventional Commit subject, push the branch, open a PR with test evidence, merge only after review/checks, then release from a `v<version>` tag.
+- For patch releases, use the next semantic patch tag, push it after the PR is merged, and let `.github/workflows/release.yml` publish the DMG and checksum.

--- a/README.ko.md
+++ b/README.ko.md
@@ -50,9 +50,11 @@ Wallpaper Engine 프로젝트를 쓰는 경우:
 
 재생 동작:
 
-- **Auto-pause behind apps**가 기본으로 켜져 있습니다.
+- Dock과 Space 전환 깜빡임을 줄이기 위해 기본값은 연속 재생입니다.
+- **Auto-pause behind apps**는 선택 옵션입니다.
 - 설정창을 닫아도 재생은 멈추지 않습니다.
 - **Open at Login**을 켜면 로그인 후 마지막 월페이퍼를 복구합니다.
+- **Play on Desktop**은 동영상 재생 뒤에 보이는 정적 macOS 데스크톱 fallback 이미지도 갱신합니다. 그래서 Dock/Space 전환 중 이전 배경화면이 드러나지 않습니다.
 - **Remove**는 Mac 라이브러리에 복사된 항목만 삭제합니다. 원본 복사 폴더나 원본 영상은 건드리지 않습니다.
 
 가져온 파일은 아래 위치에 저장됩니다.
@@ -92,7 +94,7 @@ scene 지원은 보수적입니다. 기본 image-layer scene은 동작하며, pa
 
 화면 보호기가 언제 시작되는지는 macOS가 제어합니다. 시작 시간과 암호 요구 시간은 System Settings > Lock Screen에서 정합니다. macOS가 선택된 화면 보호기를 시작하기 전까지는 일반 정적 잠금화면 배경이 보입니다.
 
-**Set Still Wallpaper**로 정적 데스크톱 배경화면도 설정할 수 있습니다. MP4, MOV, M4V 파일은 작은 Workshop preview 대신 동영상에서 한 프레임을 추출해 사용합니다.
+**Set Still Wallpaper**로 정적 데스크톱 배경화면도 명시적으로 설정할 수 있습니다. MP4, MOV, M4V 파일은 작은 Workshop preview 대신 동영상에서 한 프레임을 추출해 사용합니다. **Play on Desktop**도 전환 fallback을 위해 같은 정적 이미지 경로를 사용하지만, **Set Still Wallpaper**를 누르거나 화면 보호기 연동을 켜지 않는 한 Lock Screen cache는 쓰지 않습니다.
 
 ## 소스에서 빌드
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ Display modes:
 
 Playback notes:
 
-- **Auto-pause behind apps** is enabled by default.
+- Playback runs continuously by default to avoid Dock and Space transition flicker.
+- **Auto-pause behind apps** is optional.
 - Closing the settings window does not stop playback.
 - **Open at Login** restores the last played wallpaper after login.
+- **Play on Desktop** also updates a static macOS desktop fallback image so Dock and Space transitions do not reveal the previous wallpaper behind video playback.
 - **Remove** deletes the imported Mac-library copy only. It does not touch the original copied folder or video.
 
 Imported files are stored in:
@@ -92,7 +94,7 @@ What uses a still fallback:
 
 macOS still controls when the screen saver starts. Configure the start time and password timing in System Settings > Lock Screen. Until macOS starts the selected screen saver, the normal static Lock Screen wallpaper is shown.
 
-The app can also set a still desktop wallpaper with **Set Still Wallpaper**. For MP4, MOV, and M4V files, it extracts a frame from the video instead of using a small Workshop preview.
+The app can also set a still desktop wallpaper explicitly with **Set Still Wallpaper**. For MP4, MOV, and M4V files, it extracts a frame from the video instead of using a small Workshop preview. **Play on Desktop** uses the same still-image path as a transition fallback, but it does not write the Lock Screen cache unless you use **Set Still Wallpaper** or enable the screen saver integration.
 
 ## Build From Source
 

--- a/Sources/WorkshopWallpaperBridgeApp/AppViewModel.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/AppViewModel.swift
@@ -21,7 +21,7 @@ final class AppViewModel: ObservableObject {
             }
         }
     }
-    @Published var autoPauseWhenCovered = true {
+    @Published var autoPauseWhenCovered = false {
         didSet {
             WallpaperPlayer.shared.setAutoPauseWhenCovered(autoPauseWhenCovered)
             userDefaults.set(autoPauseWhenCovered, forKey: PreferenceKey.autoPauseWhenCovered)
@@ -437,6 +437,7 @@ extension AppViewModel {
             autoPauseWhenCovered: autoPauseWhenCovered,
             displayMode: displayMode
         )
+        let desktopFallbackError = setDesktopTransitionFallback(asset: asset)
         if remember {
             userDefaults.set(asset.id, forKey: PreferenceKey.lastPlayedAssetId)
         }
@@ -444,7 +445,21 @@ extension AppViewModel {
         let playbackStatus = autoPauseWhenCovered
             ? "Playing on the desktop layer. You can minimize this app; playback pauses only behind other apps."
             : "Playing continuously on the desktop layer. You can minimize this app."
-        status = lockScreenError.map { "\(playbackStatus) Screen Saver update failed: \($0)" } ?? playbackStatus
+        let fallbackStatus = desktopFallbackError.map {
+            " Desktop transition fallback failed: \($0)"
+        } ?? ""
+        status = lockScreenError.map {
+            "\(playbackStatus)\(fallbackStatus) Screen Saver update failed: \($0)"
+        } ?? "\(playbackStatus)\(fallbackStatus)"
+    }
+
+    private func setDesktopTransitionFallback(asset: WallpaperAsset) -> String? {
+        do {
+            _ = try systemWallpaperSetter.setDesktopStillWallpaper(from: asset)
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
     }
 
     private func refreshLockScreenAnimationConfiguration(asset: WallpaperAsset) -> String? {

--- a/Sources/WorkshopWallpaperBridgeApp/BridgeApp.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/BridgeApp.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Darwin
 import SwiftUI
 
 @main
@@ -17,6 +18,15 @@ struct WorkshopWallpaperBridgeApplication: App {
 }
 
 final class AppLifecycleDelegate: NSObject, NSApplicationDelegate {
+    private let instanceLock = AppInstanceLock()
+
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        guard instanceLock.acquire() else {
+            NSApp.terminate(nil)
+            return
+        }
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
     }
@@ -37,6 +47,43 @@ final class AppLifecycleDelegate: NSObject, NSApplicationDelegate {
         Task { @MainActor in
             WallpaperPlayer.shared.restoreVisibleWindowsAfterAppWindowChange()
         }
+    }
+}
+
+final class AppInstanceLock {
+    private let lockPath: String
+    private var fileDescriptor: Int32 = -1
+
+    init(
+        lockPath: String = URL(filePath: NSTemporaryDirectory())
+            .appending(path: "com.workshop-wallpaper-bridge.app.lock")
+            .path
+    ) {
+        self.lockPath = lockPath
+    }
+
+    func acquire() -> Bool {
+        guard fileDescriptor < 0 else {
+            return true
+        }
+        let descriptor = open(lockPath, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else {
+            return false
+        }
+        guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+            close(descriptor)
+            return false
+        }
+        fileDescriptor = descriptor
+        return true
+    }
+
+    deinit {
+        guard fileDescriptor >= 0 else {
+            return
+        }
+        flock(fileDescriptor, LOCK_UN)
+        close(fileDescriptor)
     }
 }
 

--- a/Sources/WorkshopWallpaperBridgeApp/DesktopVisibilityMonitor.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/DesktopVisibilityMonitor.swift
@@ -5,12 +5,19 @@ struct DesktopVisibilityMonitor {
     func isDesktopVisible() -> Bool {
         Self.isDesktopVisible(
             windows: windowSnapshots(),
-            currentProcessId: Int(ProcessInfo.processInfo.processIdentifier)
+            currentProcessId: Int(ProcessInfo.processInfo.processIdentifier),
+            screenFrames: NSScreen.screens.map(\.frame)
         )
     }
 
-    static func isDesktopVisible(windows: [WindowSnapshot], currentProcessId: Int) -> Bool {
-        !windows.contains { isBlockingWindow($0, currentProcessId: currentProcessId) }
+    static func isDesktopVisible(
+        windows: [WindowSnapshot],
+        currentProcessId: Int,
+        screenFrames: [CGRect] = []
+    ) -> Bool {
+        !windows.contains {
+            isBlockingWindow($0, currentProcessId: currentProcessId, screenFrames: screenFrames)
+        }
     }
 
     private func windowSnapshots() -> [WindowSnapshot] {
@@ -23,7 +30,11 @@ struct DesktopVisibilityMonitor {
         return windows.map(WindowSnapshot.init)
     }
 
-    private static func isBlockingWindow(_ window: WindowSnapshot, currentProcessId: Int) -> Bool {
+    private static func isBlockingWindow(
+        _ window: WindowSnapshot,
+        currentProcessId: Int,
+        screenFrames: [CGRect]
+    ) -> Bool {
         guard window.layer == 0, window.alpha > 0.05, window.bounds.area > 12_000 else {
             return false
         }
@@ -31,6 +42,9 @@ struct DesktopVisibilityMonitor {
             return false
         }
         if isFinderDesktopHost(window) {
+            return false
+        }
+        if isSmallDesktopOverlay(window, screenFrames: screenFrames) {
             return false
         }
         return !ignoredOwners.contains(window.ownerName)
@@ -41,6 +55,15 @@ struct DesktopVisibilityMonitor {
             return false
         }
         return window.bounds.width >= 1_000 && window.bounds.height >= 700
+    }
+
+    private static func isSmallDesktopOverlay(_ window: WindowSnapshot, screenFrames: [CGRect]) -> Bool {
+        guard max(window.bounds.width, window.bounds.height) <= 240 else {
+            return false
+        }
+        return screenFrames.contains { screen in
+            abs(window.bounds.minX - screen.minX) <= 80 || abs(window.bounds.maxX - screen.maxX) <= 80
+        }
     }
 }
 
@@ -89,9 +112,15 @@ private extension CGRect {
 }
 
 private let ignoredOwners = [
+    "AirPlayUIAgent",
+    "Continuity",
+    "Continuity Camera",
     "Window Server",
     "Dock",
     "Control Center",
+    "ControlCenter",
+    "ContinuityCaptureAgent",
+    "Handoff",
     "WindowManager",
     "Notification Center",
     "SystemUIServer"

--- a/Sources/WorkshopWallpaperBridgeApp/SystemWallpaperSetter.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/SystemWallpaperSetter.swift
@@ -39,6 +39,12 @@ struct SystemWallpaperSetter {
         }
     }
 
+    func setDesktopStillWallpaper(from asset: WallpaperAsset) throws -> URL {
+        let url = try resolveStillImage(asset)
+        try setDesktopImage(url)
+        return url
+    }
+
     private static func setDesktopImageOnAllScreens(_ url: URL) throws {
         for screen in NSScreen.screens {
             try NSWorkspace.shared.setDesktopImageURL(url, for: screen, options: [:])

--- a/Sources/WorkshopWallpaperBridgeApp/VideoWallpaperView.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/VideoWallpaperView.swift
@@ -8,18 +8,24 @@ final class VideoWallpaperView: NSView,
     WallpaperContentLifecycle {
     private let player: AVQueuePlayer
     private let looper: AVPlayerLooper
+    private let fallbackLayer = CALayer()
     private let playerLayer: AVPlayerLayer
 
-    init(url: URL, frame: CGRect, displayMode: WallpaperDisplayMode) {
+    init(url: URL, fallbackImageURL: URL?, frame: CGRect, displayMode: WallpaperDisplayMode) {
         let item = AVPlayerItem(url: url)
         let queue = AVQueuePlayer()
         player = queue
         looper = AVPlayerLooper(player: queue, templateItem: item)
         playerLayer = AVPlayerLayer(player: player)
         super.init(frame: frame)
-        playerLayer.videoGravity = WallpaperContentLayout.videoGravity(for: displayMode)
         wantsLayer = true
-        layer = playerLayer
+        layer = CALayer()
+        layer?.backgroundColor = NSColor.black.cgColor
+        configureFallbackLayer(fallbackImageURL: fallbackImageURL, displayMode: displayMode)
+        playerLayer.videoGravity = WallpaperContentLayout.videoGravity(for: displayMode)
+        layer?.addSublayer(fallbackLayer)
+        layer?.addSublayer(playerLayer)
+        layoutLayers()
         player.actionAtItemEnd = .none
         player.isMuted = true
         player.play()
@@ -32,7 +38,7 @@ final class VideoWallpaperView: NSView,
 
     override func layout() {
         super.layout()
-        layer?.frame = bounds
+        layoutLayers()
     }
 
     func setPlaybackSuspended(_ suspended: Bool) {
@@ -46,6 +52,7 @@ final class VideoWallpaperView: NSView,
     func setDisplayMode(_ displayMode: WallpaperDisplayMode) {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
+        fallbackLayer.contentsGravity = WallpaperContentLayout.imageContentsGravity(for: displayMode)
         playerLayer.videoGravity = WallpaperContentLayout.videoGravity(for: displayMode)
         CATransaction.commit()
     }
@@ -53,5 +60,26 @@ final class VideoWallpaperView: NSView,
     func prepareForClose() {
         player.pause()
         player.removeAllItems()
+        playerLayer.player = nil
+    }
+
+    private func configureFallbackLayer(fallbackImageURL: URL?, displayMode: WallpaperDisplayMode) {
+        fallbackLayer.backgroundColor = NSColor.black.cgColor
+        fallbackLayer.contentsGravity = WallpaperContentLayout.imageContentsGravity(for: displayMode)
+        fallbackLayer.contentsScale = NSScreen.main?.backingScaleFactor ?? 2
+        fallbackLayer.minificationFilter = .linear
+        fallbackLayer.magnificationFilter = .linear
+        guard let fallbackImageURL,
+              let image = NSImage(contentsOf: fallbackImageURL),
+              let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return
+        }
+        fallbackLayer.contents = cgImage
+    }
+
+    private func layoutLayers() {
+        layer?.frame = bounds
+        fallbackLayer.frame = bounds
+        playerLayer.frame = bounds
     }
 }

--- a/Sources/WorkshopWallpaperBridgeApp/WallpaperPlayer.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/WallpaperPlayer.swift
@@ -12,6 +12,8 @@ final class WallpaperPlayer {
     private var visibilityTimer: Timer?
     private var workspaceObservers: [NSObjectProtocol] = []
     private var isSuspended = false
+    private var lastScreenFrames: [CGRect] = []
+    private var pendingAutoSuspension: DispatchWorkItem?
     private let visibilityMonitor = DesktopVisibilityMonitor()
 
     func play(
@@ -30,9 +32,12 @@ final class WallpaperPlayer {
             throw PlaybackError.missingEntrypoint
         }
         let url = URL(filePath: entrypoint)
-        windows = try NSScreen.screens.map { screen in
+        let screens = NSScreen.screens
+        let screenFrames = screens.map(\.frame)
+        windows = try screens.map { screen in
             try WallpaperWindow(asset: asset, url: url, frame: screen.frame, displayMode: displayMode)
         }
+        lastScreenFrames = screenFrames
         windows.forEach { $0.show() }
         startLifecycleObservers()
         startVisibilityTimer()
@@ -48,6 +53,10 @@ final class WallpaperPlayer {
 
     func setAutoPauseWhenCovered(_ enabled: Bool) {
         autoPauseWhenCovered = enabled
+        if !enabled {
+            cancelPendingAutoSuspension()
+            setSuspended(false)
+        }
         updateVisibilityState()
     }
 
@@ -56,11 +65,13 @@ final class WallpaperPlayer {
         guard !isSuspended else {
             return
         }
-        windows.forEach { $0.show() }
+        reassertWallpaperWindowOrder()
     }
 
     func stop() {
         activeAsset = nil
+        lastScreenFrames = []
+        cancelPendingAutoSuspension()
         stopVisibilityTimer()
         stopLifecycleObservers()
         closeWindows()
@@ -77,9 +88,12 @@ final class WallpaperPlayer {
         }
         closeWindows()
         let url = URL(filePath: entrypoint)
-        windows = try NSScreen.screens.map { screen in
+        let screens = NSScreen.screens
+        let screenFrames = screens.map(\.frame)
+        windows = try screens.map { screen in
             try WallpaperWindow(asset: asset, url: url, frame: screen.frame, displayMode: displayMode)
         }
+        lastScreenFrames = screenFrames
         windows.forEach { $0.show() }
         updateVisibilityState()
     }
@@ -103,7 +117,12 @@ final class WallpaperPlayer {
 
     private func updateVisibilityState() {
         let shouldSuspend = autoPauseWhenCovered && !visibilityMonitor.isDesktopVisible()
-        setSuspended(shouldSuspend)
+        if shouldSuspend {
+            scheduleAutoSuspension()
+        } else {
+            cancelPendingAutoSuspension()
+            setSuspended(false)
+        }
     }
 
     private func setSuspended(_ suspended: Bool) {
@@ -112,6 +131,28 @@ final class WallpaperPlayer {
         }
         isSuspended = suspended
         windows.forEach { $0.setSuspended(suspended) }
+    }
+
+    private func scheduleAutoSuspension() {
+        guard pendingAutoSuspension == nil, !isSuspended else {
+            return
+        }
+        let workItem = DispatchWorkItem { [weak self] in
+            Task { @MainActor in
+                guard let self, self.autoPauseWhenCovered, !self.visibilityMonitor.isDesktopVisible() else {
+                    return
+                }
+                self.pendingAutoSuspension = nil
+                self.setSuspended(true)
+            }
+        }
+        pendingAutoSuspension = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: workItem)
+    }
+
+    private func cancelPendingAutoSuspension() {
+        pendingAutoSuspension?.cancel()
+        pendingAutoSuspension = nil
     }
 
     private func startLifecycleObservers() {
@@ -126,12 +167,26 @@ final class WallpaperPlayer {
             center.addObserver(forName: NSWorkspace.didWakeNotification, object: nil, queue: .main) { [weak self] _ in
                 Task { @MainActor in self?.reopenAfterWake() }
             },
+            center.addObserver(
+                forName: NSWorkspace.didActivateApplicationNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in self?.scheduleWallpaperWindowOrderReassertion() }
+            },
+            center.addObserver(
+                forName: NSWorkspace.activeSpaceDidChangeNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in self?.scheduleWallpaperWindowOrderReassertion() }
+            },
             NotificationCenter.default.addObserver(
                 forName: NSApplication.didChangeScreenParametersNotification,
                 object: nil,
                 queue: .main
             ) { [weak self] _ in
-                Task { @MainActor in self?.reopenAfterWake() }
+                Task { @MainActor in self?.reopenAfterScreenFrameChange() }
             }
         ]
     }
@@ -155,6 +210,66 @@ final class WallpaperPlayer {
             closeWindows()
         }
     }
+
+    private func reopenAfterScreenFrameChange() {
+        guard activeAsset != nil else {
+            return
+        }
+        let currentScreenFrames = NSScreen.screens.map(\.frame)
+        guard WallpaperScreenFrames.shouldReopenWindows(
+            previous: lastScreenFrames,
+            current: currentScreenFrames
+        ) else {
+            reassertWallpaperWindowOrder()
+            return
+        }
+        reopenAfterWake()
+    }
+
+    private func reassertWallpaperWindowOrder() {
+        windows.forEach { $0.reassertDesktopOrder() }
+    }
+
+    private func scheduleWallpaperWindowOrderReassertion() {
+        wakeWallpaperForAppTransition()
+        reassertWallpaperWindowOrder()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+            Task { @MainActor in
+                self?.updateVisibilityState()
+                self?.reassertWallpaperWindowOrder()
+            }
+        }
+    }
+
+    private func wakeWallpaperForAppTransition() {
+        guard autoPauseWhenCovered else {
+            return
+        }
+        cancelPendingAutoSuspension()
+        setSuspended(false)
+        updateVisibilityState()
+    }
+}
+
+enum WallpaperScreenFrames {
+    static func shouldReopenWindows(previous: [CGRect], current: [CGRect]) -> Bool {
+        normalized(previous) != normalized(current)
+    }
+
+    private static func normalized(_ frames: [CGRect]) -> [CGRect] {
+        frames.sorted { lhs, rhs in
+            if lhs.minX != rhs.minX {
+                return lhs.minX < rhs.minX
+            }
+            if lhs.minY != rhs.minY {
+                return lhs.minY < rhs.minY
+            }
+            if lhs.width != rhs.width {
+                return lhs.width < rhs.width
+            }
+            return lhs.height < rhs.height
+        }
+    }
 }
 
 @MainActor
@@ -171,7 +286,7 @@ private final class WallpaperWindow {
             defer: false
         )
         window.level = WallpaperWindowLevel.desktopWallpaper
-        window.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
+        window.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle, .fullScreenAuxiliary]
         window.ignoresMouseEvents = true
         window.canHide = false
         window.isReleasedWhenClosed = false
@@ -182,6 +297,13 @@ private final class WallpaperWindow {
     }
 
     func show() {
+        guard !window.isVisible else {
+            return
+        }
+        window.orderFrontRegardless()
+    }
+
+    func reassertDesktopOrder() {
         window.orderFrontRegardless()
     }
 
@@ -208,7 +330,13 @@ private final class WallpaperWindow {
         let contentFrame = WallpaperContentLayout.contentFrame(for: frame)
         switch asset.kind {
         case .video:
-            return VideoWallpaperView(url: url, frame: contentFrame, displayMode: displayMode)
+            let fallbackImageURL = try? StillWallpaperImageProvider().stillImageURL(for: asset)
+            return VideoWallpaperView(
+                url: url,
+                fallbackImageURL: fallbackImageURL,
+                frame: contentFrame,
+                displayMode: displayMode
+            )
         case .web:
             return RestrictedWebWallpaperView(
                 url: url,

--- a/Tests/WorkshopWallpaperBridgeAppTests/AppInstanceLockTests.swift
+++ b/Tests/WorkshopWallpaperBridgeAppTests/AppInstanceLockTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import XCTest
+@testable import WorkshopWallpaperBridgeApp
+
+final class AppInstanceLockTests: XCTestCase {
+    func testSecondInstanceCannotAcquireHeldLock() {
+        // Given
+        let lockPath = temporaryLockPath()
+        let first = AppInstanceLock(lockPath: lockPath)
+        let second = AppInstanceLock(lockPath: lockPath)
+
+        // Then
+        XCTAssertTrue(first.acquire())
+        XCTAssertFalse(second.acquire())
+    }
+
+    func testLockCanBeAcquiredAfterFirstInstanceReleasesIt() {
+        // Given
+        let lockPath = temporaryLockPath()
+        var first: AppInstanceLock? = AppInstanceLock(lockPath: lockPath)
+
+        // When
+        XCTAssertTrue(first?.acquire() ?? false)
+        first = nil
+        let second = AppInstanceLock(lockPath: lockPath)
+
+        // Then
+        XCTAssertTrue(second.acquire())
+    }
+
+    func testOpenFailureDoesNotAcquireLock() {
+        // Given
+        let lock = AppInstanceLock(lockPath: NSTemporaryDirectory())
+
+        // Then
+        XCTAssertFalse(lock.acquire())
+    }
+
+    private func temporaryLockPath() -> String {
+        let filename = "wwb-\(UUID().uuidString).lock"
+        return URL(filePath: NSTemporaryDirectory())
+            .appending(path: filename)
+            .path
+    }
+}

--- a/Tests/WorkshopWallpaperBridgeAppTests/AppViewModelTests.swift
+++ b/Tests/WorkshopWallpaperBridgeAppTests/AppViewModelTests.swift
@@ -187,6 +187,21 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertFalse(model.autoPauseWhenCovered)
     }
 
+    func testInitDefaultsToContinuousPlayback() throws {
+        // Given
+        let defaults = try makeUserDefaults()
+
+        // When
+        let model = AppViewModel(
+            store: LibraryStore(root: try makeTempDirectory()),
+            loginItemController: MockLoginItemController(),
+            userDefaults: defaults
+        )
+
+        // Then
+        XCTAssertFalse(model.autoPauseWhenCovered)
+    }
+
     func testInitRestoresLockScreenAnimationPreferenceWithoutInstalling() throws {
         // Given
         let defaults = try makeUserDefaults()

--- a/Tests/WorkshopWallpaperBridgeAppTests/DesktopVisibilityMonitorTests.swift
+++ b/Tests/WorkshopWallpaperBridgeAppTests/DesktopVisibilityMonitorTests.swift
@@ -41,6 +41,130 @@ final class DesktopVisibilityMonitorTests: XCTestCase {
         XCTAssertTrue(visible)
     }
 
+    func testStageManagerAppThumbnailDoesNotPausePlayback() {
+        // Given
+        let windows = [
+            DesktopVisibilityMonitor.WindowSnapshot(
+                ownerName: "Code",
+                processId: 100,
+                layer: 0,
+                alpha: 1,
+                bounds: CGRect(x: 15, y: 420, width: 127, height: 149)
+            )
+        ]
+
+        // When
+        let visible = DesktopVisibilityMonitor.isDesktopVisible(
+            windows: windows,
+            currentProcessId: 200,
+            screenFrames: [CGRect(x: 0, y: 0, width: 1470, height: 956)]
+        )
+
+        // Then
+        XCTAssertTrue(visible)
+    }
+
+    func testSmallCenteredUserWindowStillPausesPlayback() {
+        // Given
+        let windows = [
+            DesktopVisibilityMonitor.WindowSnapshot(
+                ownerName: "Code",
+                processId: 100,
+                layer: 0,
+                alpha: 1,
+                bounds: CGRect(x: 520, y: 320, width: 220, height: 220)
+            )
+        ]
+
+        // When
+        let visible = DesktopVisibilityMonitor.isDesktopVisible(
+            windows: windows,
+            currentProcessId: 200,
+            screenFrames: [CGRect(x: 0, y: 0, width: 1470, height: 956)]
+        )
+
+        // Then
+        XCTAssertFalse(visible)
+    }
+
+    func testContinuityAndHandoffSystemWindowsDoNotPausePlayback() {
+        // Given
+        let windows = [
+            DesktopVisibilityMonitor.WindowSnapshot(
+                ownerName: "ContinuityCaptureAgent",
+                processId: 100,
+                layer: 0,
+                alpha: 1,
+                bounds: CGRect(x: 0, y: 0, width: 390, height: 844)
+            ),
+            DesktopVisibilityMonitor.WindowSnapshot(
+                ownerName: "Handoff",
+                processId: 101,
+                layer: 0,
+                alpha: 1,
+                bounds: CGRect(x: 0, y: 0, width: 390, height: 844)
+            )
+        ]
+
+        // When
+        let visible = DesktopVisibilityMonitor.isDesktopVisible(windows: windows, currentProcessId: 200)
+
+        // Then
+        XCTAssertTrue(
+            visible,
+            "Continuity and Handoff system windows should not pause desktop wallpaper playback."
+        )
+    }
+
+    func testAdditionalContinuitySystemWindowsDoNotPausePlayback() {
+        let ownerNames = [
+            "AirPlayUIAgent",
+            "Continuity",
+            "Continuity Camera",
+            "ControlCenter"
+        ]
+
+        for ownerName in ownerNames {
+            let windows = [
+                DesktopVisibilityMonitor.WindowSnapshot(
+                    ownerName: ownerName,
+                    processId: 100,
+                    layer: 0,
+                    alpha: 1,
+                    bounds: CGRect(x: 0, y: 0, width: 390, height: 844)
+                )
+            ]
+
+            let visible = DesktopVisibilityMonitor.isDesktopVisible(windows: windows, currentProcessId: 200)
+
+            XCTAssertTrue(visible, "\(ownerName) should not pause desktop wallpaper playback.")
+        }
+    }
+
+    func testUserWindowsWithContinuityLikeNamesStillPausePlayback() {
+        let ownerNames = [
+            "Continuity Studio",
+            "Handoff Notes",
+            "iPhone Hotspot Preview"
+        ]
+
+        for ownerName in ownerNames {
+            let windows = [
+                DesktopVisibilityMonitor.WindowSnapshot(
+                    ownerName: ownerName,
+                    processId: 100,
+                    layer: 0,
+                    alpha: 1,
+                    bounds: CGRect(x: 0, y: 0, width: 900, height: 700)
+                )
+            ]
+
+            let visible = DesktopVisibilityMonitor.isDesktopVisible(windows: windows, currentProcessId: 200)
+
+            XCTAssertFalse(visible, "\(ownerName) should still pause desktop wallpaper playback.")
+        }
+    }
+
     func testLargeUserAppWindowPausesPlayback() {
         // Given
         let windows = [

--- a/Tests/WorkshopWallpaperBridgeAppTests/SystemWallpaperSetterTests.swift
+++ b/Tests/WorkshopWallpaperBridgeAppTests/SystemWallpaperSetterTests.swift
@@ -64,6 +64,42 @@ final class SystemWallpaperSetterTests: XCTestCase {
         XCTAssertEqual(result.lockScreenErrorDescription, "The macOS Lock Screen wallpaper cache is not available.")
     }
 
+    func testDesktopStillWallpaperDoesNotWriteLockScreenCache() throws {
+        // Given
+        let imageURL = URL(filePath: "/tmp/preview.jpg")
+        let asset = makeAsset(kind: .image, entrypoint: imageURL.path, thumbnail: nil)
+        var desktopImageURL: URL?
+        var didWriteLockScreen = false
+        let setter = SystemWallpaperSetter(
+            resolveStillImage: { _ in imageURL },
+            setDesktopImage: { desktopImageURL = $0 },
+            setLockScreenImage: { _ in
+                didWriteLockScreen = true
+                return nil
+            }
+        )
+
+        // When
+        let result = try setter.setDesktopStillWallpaper(from: asset)
+
+        // Then
+        XCTAssertEqual(result, imageURL)
+        XCTAssertEqual(desktopImageURL, imageURL)
+        XCTAssertFalse(didWriteLockScreen)
+    }
+
+    func testPlaybackConfiguresDesktopTransitionFallback() throws {
+        // Given
+        let source = try String(contentsOfFile: "Sources/WorkshopWallpaperBridgeApp/AppViewModel.swift")
+        let start = try XCTUnwrap(source.range(of: "private func play(asset: WallpaperAsset, remember: Bool)"))
+        let end = try XCTUnwrap(source.range(of: "private func refreshLockScreenAnimationConfiguration", range: start.lowerBound..<source.endIndex))
+        let body = String(source[start.lowerBound..<end.lowerBound])
+
+        // Then
+        XCTAssertTrue(body.contains("setDesktopTransitionFallback(asset: asset)"))
+        XCTAssertTrue(source.contains("setDesktopStillWallpaper(from: asset)"))
+    }
+
     func testStillImageProviderExtractsVideoFrameBeforeGifThumbnail() throws {
         // Given
         let root = try makeTempDirectory()

--- a/Tests/WorkshopWallpaperBridgeAppTests/WallpaperPlayerSuspensionTests.swift
+++ b/Tests/WorkshopWallpaperBridgeAppTests/WallpaperPlayerSuspensionTests.swift
@@ -1,7 +1,140 @@
 import Foundation
 import XCTest
+@testable import WorkshopWallpaperBridgeApp
 
 final class WallpaperPlayerSuspensionTests: XCTestCase {
+    func testNoopScreenParameterNotificationDoesNotNeedWindowReopen() {
+        // Given
+        let frames = [
+            CGRect(x: 0, y: 0, width: 1470, height: 956),
+            CGRect(x: -1440, y: 0, width: 1440, height: 900)
+        ]
+
+        // Then
+        XCTAssertFalse(WallpaperScreenFrames.shouldReopenWindows(previous: frames, current: frames))
+    }
+
+    func testNoopScreenParameterNotificationReassertsDesktopWindowOrder() throws {
+        // Given
+        let source = try String(contentsOfFile: "Sources/WorkshopWallpaperBridgeApp/WallpaperPlayer.swift")
+        let start = try XCTUnwrap(source.range(of: "private func reopenAfterScreenFrameChange()"))
+        let end = try XCTUnwrap(source.range(of: "enum WallpaperScreenFrames", range: start.lowerBound..<source.endIndex))
+        let body = String(source[start.lowerBound..<end.lowerBound])
+
+        // Then
+        XCTAssertTrue(body.contains("reassertWallpaperWindowOrder()"))
+        XCTAssertFalse(body.contains("try play("))
+        XCTAssertFalse(body.contains("closeWindows()"))
+    }
+
+    func testActiveApplicationChangesReassertDesktopWindowOrder() throws {
+        // Given
+        let source = try String(contentsOfFile: "Sources/WorkshopWallpaperBridgeApp/WallpaperPlayer.swift")
+        let start = try XCTUnwrap(source.range(of: "private func startLifecycleObservers()"))
+        let end = try XCTUnwrap(source.range(of: "private func stopLifecycleObservers()", range: start.lowerBound..<source.endIndex))
+        let body = String(source[start.lowerBound..<end.lowerBound])
+
+        // Then
+        XCTAssertTrue(body.contains("NSWorkspace.didActivateApplicationNotification"))
+        XCTAssertTrue(body.contains("scheduleWallpaperWindowOrderReassertion()"))
+    }
+
+    func testActiveSpaceChangesReassertDesktopWindowOrder() throws {
+        // Given
+        let source = try String(contentsOfFile: "Sources/WorkshopWallpaperBridgeApp/WallpaperPlayer.swift")
+        let start = try XCTUnwrap(source.range(of: "private func startLifecycleObservers()"))
+        let end = try XCTUnwrap(source.range(of: "private func stopLifecycleObservers()", range: start.lowerBound..<source.endIndex))
+        let body = String(source[start.lowerBound..<end.lowerBound])
+
+        // Then
+        XCTAssertTrue(body.contains("NSWorkspace.activeSpaceDidChangeNotification"))
+        XCTAssertTrue(body.contains("scheduleWallpaperWindowOrderReassertion()"))
+    }
+
+    func testAutoPauseUsesDelayedSuspensionToAvoidDockSwitchFlicker() throws {
+        // Given
+        let source = try String(contentsOfFile: "Sources/WorkshopWallpaperBridgeApp/WallpaperPlayer.swift")
+
+        // Then
+        XCTAssertTrue(source.contains("private var pendingAutoSuspension"))
+        XCTAssertTrue(source.contains("scheduleAutoSuspension()"))
+        XCTAssertTrue(source.contains("cancelPendingAutoSuspension()"))
+        XCTAssertTrue(source.contains(".now() + 1.5"))
+    }
+
+    func testActiveApplicationChangesReevaluateVisibilityBeforeReassertingOrder() throws {
+        // Given
+        let source = try String(contentsOfFile: "Sources/WorkshopWallpaperBridgeApp/WallpaperPlayer.swift")
+        let start = try XCTUnwrap(source.range(of: "private func scheduleWallpaperWindowOrderReassertion()"))
+        let end = try XCTUnwrap(source.range(of: "enum WallpaperScreenFrames", range: start.lowerBound..<source.endIndex))
+        let body = String(source[start.lowerBound..<end.lowerBound])
+
+        // Then
+        XCTAssertTrue(body.contains("updateVisibilityState()"))
+        XCTAssertTrue(body.contains("reassertWallpaperWindowOrder()"))
+    }
+
+    func testActiveApplicationChangesWakeSuspendedWallpaperBeforeDelayedPause() throws {
+        // Given
+        let source = try String(contentsOfFile: "Sources/WorkshopWallpaperBridgeApp/WallpaperPlayer.swift")
+        let start = try XCTUnwrap(source.range(of: "private func wakeWallpaperForAppTransition()"))
+        let end = try XCTUnwrap(source.range(of: "enum WallpaperScreenFrames", range: start.lowerBound..<source.endIndex))
+        let body = String(source[start.lowerBound..<end.lowerBound])
+
+        // Then
+        XCTAssertTrue(body.contains("cancelPendingAutoSuspension()"))
+        XCTAssertTrue(body.contains("setSuspended(false)"))
+        XCTAssertTrue(body.contains("updateVisibilityState()"))
+    }
+
+    func testWallpaperWindowsJoinFullscreenAppSpaces() throws {
+        // Given
+        let source = try String(contentsOfFile: "Sources/WorkshopWallpaperBridgeApp/WallpaperPlayer.swift")
+
+        // Then
+        XCTAssertTrue(source.contains(".canJoinAllSpaces"))
+        XCTAssertTrue(source.contains(".fullScreenAuxiliary"))
+    }
+
+    func testRealScreenFrameChangeStillReopensWallpaperWindows() {
+        // Given
+        let previous = [
+            CGRect(x: 0, y: 0, width: 1470, height: 956)
+        ]
+        let current = [
+            CGRect(x: 0, y: 0, width: 1728, height: 1117)
+        ]
+
+        // Then
+        XCTAssertTrue(WallpaperScreenFrames.shouldReopenWindows(previous: previous, current: current))
+    }
+
+    func testReorderedScreenFramesDoNotReopenWallpaperWindows() {
+        // Given
+        let previous = [
+            CGRect(x: 0, y: 0, width: 1470, height: 956),
+            CGRect(x: -1440, y: 0, width: 1440, height: 900)
+        ]
+        let current = Array(previous.reversed())
+
+        // Then
+        XCTAssertFalse(WallpaperScreenFrames.shouldReopenWindows(previous: previous, current: current))
+    }
+
+    func testScreenCountChangeReopensWallpaperWindows() {
+        // Given
+        let previous = [
+            CGRect(x: 0, y: 0, width: 1470, height: 956),
+            CGRect(x: -1440, y: 0, width: 1440, height: 900)
+        ]
+        let current = [
+            CGRect(x: 0, y: 0, width: 1470, height: 956)
+        ]
+
+        // Then
+        XCTAssertTrue(WallpaperScreenFrames.shouldReopenWindows(previous: previous, current: current))
+    }
+
     func testAutoPauseDoesNotHideWallpaperWindow() throws {
         // Given
         let source = try String(contentsOfFile: "Sources/WorkshopWallpaperBridgeApp/WallpaperPlayer.swift")
@@ -54,6 +187,20 @@ final class WallpaperPlayerSuspensionTests: XCTestCase {
         XCTAssertTrue(source.contains("window.isReleasedWhenClosed = false"))
     }
 
+    func testWallpaperWindowCanReassertOrderWithoutRecreatingContent() throws {
+        // Given
+        let source = try String(contentsOfFile: "Sources/WorkshopWallpaperBridgeApp/WallpaperPlayer.swift")
+        let windowStart = try XCTUnwrap(source.range(of: "private final class WallpaperWindow"))
+        let start = try XCTUnwrap(source.range(of: "func reassertDesktopOrder()", range: windowStart.lowerBound..<source.endIndex))
+        let end = try XCTUnwrap(source.range(of: "func close()", range: start.lowerBound..<source.endIndex))
+        let body = String(source[start.lowerBound..<end.lowerBound])
+
+        // Then
+        XCTAssertTrue(body.contains("window.orderFrontRegardless()"))
+        XCTAssertFalse(body.contains("makeContentView"))
+        XCTAssertFalse(body.contains("close()"))
+    }
+
     func testSceneWallpaperReceivesPreviewFallback() throws {
         // Given
         let playerSource = try String(contentsOfFile: "Sources/WorkshopWallpaperBridgeApp/WallpaperPlayer.swift")
@@ -64,6 +211,19 @@ final class WallpaperPlayerSuspensionTests: XCTestCase {
         XCTAssertTrue(playerSource.contains("previewURL: previewURL"))
         XCTAssertTrue(sceneSource.contains("private let previewLayer = CALayer()"))
         XCTAssertTrue(sceneSource.contains("sceneLayer.backgroundColor = nil"))
+    }
+
+    func testVideoWallpaperKeepsStillFallbackBehindPlayerLayer() throws {
+        // Given
+        let playerSource = try String(contentsOfFile: "Sources/WorkshopWallpaperBridgeApp/WallpaperPlayer.swift")
+        let videoSource = try String(contentsOfFile: "Sources/WorkshopWallpaperBridgeApp/VideoWallpaperView.swift")
+
+        // Then
+        XCTAssertTrue(playerSource.contains("let fallbackImageURL = try? StillWallpaperImageProvider().stillImageURL(for: asset)"))
+        XCTAssertTrue(playerSource.contains("fallbackImageURL: fallbackImageURL"))
+        XCTAssertTrue(videoSource.contains("private let fallbackLayer = CALayer()"))
+        XCTAssertTrue(videoSource.contains("layer?.addSublayer(fallbackLayer)"))
+        XCTAssertTrue(videoSource.contains("layer?.addSublayer(playerLayer)"))
     }
 
     func testSceneWallpaperAppliesTransformAndOpacityAnimationChannels() throws {


### PR DESCRIPTION
## Summary
- Prevent wallpaper flicker during Dock, Space, and app switching by keeping wallpaper windows alive and reasserting desktop-layer ordering instead of recreating content.
- Add a still fallback behind video playback and set the macOS desktop still image during playback so transition gaps do not reveal the previous desktop wallpaper.
- Default new installs to continuous playback, preserve explicit auto-pause preferences, and add a single-instance app lock.
- Document open-source branch, PR, and patch-release workflow in `AGENTS.md` and `CLAUDE.md`.

## Root Cause
Dock/Space/app activation can briefly reorder or expose desktop layers. When the wallpaper player was suspended or when system window changes caused window recreation/order churn, AVPlayer could show a blank transition and macOS could reveal the underlying still desktop image.

## Validation
- `swift test` passed: 109 tests.
- `bash Scripts/package-app.sh` passed and produced `dist/WorkshopWallpaperBridge-macOS-arm64.dmg`.
- Relaunched the packaged app locally.
- Used Computer Use to bring KakaoTalk forward and macOS app activation to switch KakaoTalk ↔ Codex repeatedly.
- Captured transition video and reviewed frame contact sheets; no frame showed the old desktop wallpaper flashing through.
- LSP diagnostics: clean for changed app files checked during implementation.

## Release Notes Draft
Fixes a macOS desktop wallpaper flicker during Dock, Space, and app switching, especially when moving between apps such as KakaoTalk and Codex. The wallpaper now keeps a still fallback behind video playback and avoids unnecessary desktop-window recreation during system UI transitions.

## AI Assistance
Implemented and verified with Codex/OmX assistance.
