### PR TITLE
fix: require notarized macOS releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,79 @@ jobs:
       - name: Run tests
         run: swift test
 
+      - name: Validate release signing secrets
+        env:
+          MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64 }}
+          MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD }}
+          MACOS_NOTARY_APPLE_ID: ${{ secrets.MACOS_NOTARY_APPLE_ID }}
+          MACOS_NOTARY_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
+          MACOS_NOTARY_PASSWORD: ${{ secrets.MACOS_NOTARY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in \
+            MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64 \
+            MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD \
+            MACOS_NOTARY_APPLE_ID \
+            MACOS_NOTARY_TEAM_ID \
+            MACOS_NOTARY_PASSWORD
+          do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::$name is required for a signed and notarized public release."
+              missing=1
+            fi
+          done
+          exit "$missing"
+
+      - name: Import Developer ID certificate
+        env:
+          MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64 }}
+          MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD }}
+          MACOS_NOTARY_APPLE_ID: ${{ secrets.MACOS_NOTARY_APPLE_ID }}
+          MACOS_NOTARY_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
+          MACOS_NOTARY_PASSWORD: ${{ secrets.MACOS_NOTARY_PASSWORD }}
+          NOTARY_PROFILE: workshop-wallpaper-bridge-notary
+        run: |
+          set -euo pipefail
+          keychain_path="$RUNNER_TEMP/release-signing.keychain-db"
+          keychain_password="$(uuidgen)"
+          certificate_path="$RUNNER_TEMP/developer-id-application.p12"
+          echo "NOTARY_KEYCHAIN=$keychain_path" >> "$GITHUB_ENV"
+
+          if ! printf '%s' "$MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64" | base64 --decode > "$certificate_path" 2>/dev/null; then
+            printf '%s' "$MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64" | base64 -D > "$certificate_path"
+          fi
+
+          security create-keychain -p "$keychain_password" "$keychain_path"
+          security set-keychain-settings -lut 21600 "$keychain_path"
+          security unlock-keychain -p "$keychain_password" "$keychain_path"
+          security list-keychains -d user -s "$keychain_path"
+          security default-keychain -s "$keychain_path"
+          security import "$certificate_path" \
+            -k "$keychain_path" \
+            -P "$MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "$keychain_password" \
+            "$keychain_path"
+          security find-identity -v -p codesigning "$keychain_path"
+          xcrun notarytool store-credentials "$NOTARY_PROFILE" \
+            --apple-id "$MACOS_NOTARY_APPLE_ID" \
+            --team-id "$MACOS_NOTARY_TEAM_ID" \
+            --password "$MACOS_NOTARY_PASSWORD" \
+            --keychain "$keychain_path"
+
       - name: Build app bundle and DMG
         env:
           APP_VERSION: ${{ steps.version.outputs.version }}
           BUNDLE_VERSION: ${{ github.run_number }}
+          SIGN_IDENTITY: Developer ID Application
+          NOTARY_PROFILE: workshop-wallpaper-bridge-notary
+          REQUIRE_SIGNING: "1"
+          REQUIRE_NOTARIZATION: "1"
         run: bash Scripts/package-app.sh
 
       - name: Create checksum
@@ -83,4 +152,12 @@ jobs:
               --title "$TAG_NAME" \
               --generate-notes \
               --verify-tag
+          fi
+
+      - name: Clean up signing keychain
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -n "${NOTARY_KEYCHAIN:-}" ] && [ -f "$NOTARY_KEYCHAIN" ]; then
+            security delete-keychain "$NOTARY_KEYCHAIN" || true
           fi

--- a/README.ko.md
+++ b/README.ko.md
@@ -26,7 +26,7 @@ Workshop Wallpaper Bridge가 도움이 되었다면 [Patreon](https://www.patreo
 2. **Workshop Wallpaper Bridge.app**을 **Applications**로 드래그합니다.
 3. 앱을 엽니다. Dock 앱이 아니라 메뉴바 유틸리티로 실행됩니다.
 
-릴리즈가 아직 공증되지 않은 경우 macOS가 확인되지 않은 개발자 경고를 띄울 수 있습니다. 원하면 Swift로 직접 빌드해서 실행할 수 있습니다.
+공개 릴리즈는 Developer ID로 서명하고 공증한 뒤, 다운로드 quarantine이 붙은 상태의 Gatekeeper 검증까지 통과한 DMG만 업로드합니다. 다운로드한 릴리즈가 손상되었다고 표시되면 다음 릴리즈를 받고, macOS 버전과 릴리즈 태그를 이슈에 남겨 주세요.
 
 **Auto-check Updates**가 켜져 있으면 앱이 GitHub Releases에서 업데이트를 자동 확인합니다. 설정 창의 **Check Updates** 또는 메뉴바 메뉴의 **Check for Updates**로 수동 확인할 수 있습니다. 새 릴리즈가 있으면 **Download Update**가 최신 DMG를 다운로드합니다.
 
@@ -154,7 +154,7 @@ swift run wwbctl scene-engine-info "/path/to/scene.pkg"
 swift run wwbctl doctor
 ```
 
-공개 릴리즈를 서명/공증하려면 `Scripts/package-app.sh` 실행 전에 `SIGN_IDENTITY`, `NOTARY_PROFILE`, `REQUIRE_SIGNING=1`을 설정합니다.
+공개 릴리즈를 서명/공증하려면 `Scripts/package-app.sh` 실행 전에 `SIGN_IDENTITY`, `NOTARY_PROFILE`, `REQUIRE_SIGNING=1`, `REQUIRE_NOTARIZATION=1`을 설정합니다. 릴리즈 workflow에는 `MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64`, `MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD`, `MACOS_NOTARY_APPLE_ID`, `MACOS_NOTARY_TEAM_ID`, `MACOS_NOTARY_PASSWORD` GitHub Secrets가 필요합니다.
 
 ## 문제 해결
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Download the latest `WorkshopWallpaperBridge-macOS-arm64.dmg` from [Releases](ht
 2. Drag **Workshop Wallpaper Bridge.app** to **Applications**.
 3. Open the app. It runs as a menu bar utility, not a Dock app.
 
-macOS may warn that the app is from an unidentified developer if the release is not notarized yet. You can still build from source with Swift.
+Public releases are Developer ID signed, notarized, and Gatekeeper-checked with download quarantine applied before upload. If macOS reports that a downloaded release is damaged, use the next release and file an issue with the macOS version and release tag.
 
 The app checks GitHub Releases for updates automatically when **Auto-check Updates** is enabled. Use **Check Updates** from the settings window, or **Check for Updates** from the menu bar menu, to check manually. When a newer release exists, **Download Update** downloads the latest DMG.
 
@@ -154,7 +154,7 @@ swift run wwbctl scene-engine-info "/path/to/scene.pkg"
 swift run wwbctl doctor
 ```
 
-For signed public releases, set `SIGN_IDENTITY`, `NOTARY_PROFILE`, and `REQUIRE_SIGNING=1` before running `Scripts/package-app.sh`.
+For signed public releases, set `SIGN_IDENTITY`, `NOTARY_PROFILE`, `REQUIRE_SIGNING=1`, and `REQUIRE_NOTARIZATION=1` before running `Scripts/package-app.sh`. The release workflow also requires the `MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64`, `MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD`, `MACOS_NOTARY_APPLE_ID`, `MACOS_NOTARY_TEAM_ID`, and `MACOS_NOTARY_PASSWORD` GitHub Secrets.
 
 ## Troubleshooting
 

--- a/Scripts/package-app.sh
+++ b/Scripts/package-app.sh
@@ -15,15 +15,37 @@ APP_VERSION="${APP_VERSION:-1.1.3}"
 BUNDLE_VERSION="${BUNDLE_VERSION:-10}"
 SIGN_IDENTITY="${SIGN_IDENTITY:-}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-}"
+NOTARY_KEYCHAIN="${NOTARY_KEYCHAIN:-}"
 REQUIRE_SIGNING="${REQUIRE_SIGNING:-0}"
+REQUIRE_NOTARIZATION="${REQUIRE_NOTARIZATION:-0}"
 DMG_STAGING=""
+DMG_VERIFY_DIR=""
+DMG_VERIFY_MOUNT=""
 
 cleanup() {
+  if [ -n "$DMG_VERIFY_MOUNT" ] && mount | grep -q "on $DMG_VERIFY_MOUNT "; then
+    hdiutil detach "$DMG_VERIFY_MOUNT" >/dev/null 2>&1 || true
+  fi
+  if [ -n "$DMG_VERIFY_DIR" ] && [ -d "$DMG_VERIFY_DIR" ]; then
+    rm -rf "$DMG_VERIFY_DIR"
+  fi
   if [ -n "$DMG_STAGING" ] && [ -d "$DMG_STAGING" ]; then
     rm -rf "$DMG_STAGING"
   fi
 }
 trap cleanup EXIT
+
+require_notarization_inputs() {
+  if [ "$REQUIRE_NOTARIZATION" = "1" ] && [ -z "$NOTARY_PROFILE" ]; then
+    printf '%s\n' "NOTARY_PROFILE is required when REQUIRE_NOTARIZATION=1." >&2
+    exit 1
+  fi
+
+  if [ -n "$NOTARY_PROFILE" ] && [ -z "$SIGN_IDENTITY" ]; then
+    printf '%s\n' "NOTARY_PROFILE requires SIGN_IDENTITY because Apple notarization needs a signed app." >&2
+    exit 1
+  fi
+}
 
 strip_quarantine_metadata() {
   local path
@@ -56,6 +78,38 @@ assert_no_quarantine_metadata() {
   fi
 }
 
+verify_gatekeeper_accepts_quarantined_app_from_dmg() {
+  local mounted_app
+  local copied_app
+  local quarantine_stamp
+
+  DMG_VERIFY_DIR="$(mktemp -d)"
+  DMG_VERIFY_MOUNT="$DMG_VERIFY_DIR/mount"
+  mkdir -p "$DMG_VERIFY_MOUNT"
+
+  hdiutil attach \
+    -nobrowse \
+    -readonly \
+    -mountpoint "$DMG_VERIFY_MOUNT" \
+    "$DMG_PATH" >/dev/null
+
+  mounted_app="$DMG_VERIFY_MOUNT/$APP_NAME.app"
+  copied_app="$DMG_VERIFY_DIR/$APP_NAME.app"
+  if [ ! -d "$mounted_app" ]; then
+    printf '%s\n' "notarized DMG does not contain $APP_NAME.app." >&2
+    exit 1
+  fi
+
+  cp -R "$mounted_app" "$copied_app"
+  hdiutil detach "$DMG_VERIFY_MOUNT" >/dev/null
+  DMG_VERIFY_MOUNT=""
+
+  quarantine_stamp="$(printf '%x' "$(date +%s)")"
+  xattr -w com.apple.quarantine "0081;${quarantine_stamp};WorkshopWallpaperBridge;https://github.com/3x-haust/workshop-wallpaper-bridge" "$copied_app"
+  spctl --assess --type execute --verbose=4 "$copied_app"
+}
+
+require_notarization_inputs
 cd "$ROOT"
 swift build -c release
 rm -rf "$ROOT/dist"
@@ -162,12 +216,13 @@ if [ -n "$SIGN_IDENTITY" ]; then
   codesign --verify --verbose=2 "$DMG_PATH"
 fi
 if [ -n "$NOTARY_PROFILE" ]; then
-  if [ -z "$SIGN_IDENTITY" ]; then
-    printf '%s\n' "NOTARY_PROFILE requires SIGN_IDENTITY because Apple notarization needs a signed app." >&2
-    exit 1
+  notary_args=(--keychain-profile "$NOTARY_PROFILE")
+  if [ -n "$NOTARY_KEYCHAIN" ]; then
+    notary_args+=(--keychain "$NOTARY_KEYCHAIN")
   fi
-  xcrun notarytool submit "$DMG_PATH" --keychain-profile "$NOTARY_PROFILE" --wait
+  xcrun notarytool submit "$DMG_PATH" "${notary_args[@]}" --wait
   xcrun stapler staple "$DMG_PATH"
   spctl -a -vv --type open "$DMG_PATH"
+  verify_gatekeeper_accepts_quarantined_app_from_dmg
 fi
 printf '%s\n' "$DMG_PATH"

--- a/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
+++ b/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
@@ -115,6 +115,30 @@ final class DocumentationTests: XCTestCase {
         XCTAssertTrue(workflow.contains("contents: write"))
     }
 
+    func testReleaseWorkflowRequiresSignedNotarizedGatekeeperCheckedDmg() throws {
+        let workflow = try String(contentsOfFile: ".github/workflows/release.yml")
+
+        XCTAssertTrue(workflow.contains("MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64"))
+        XCTAssertTrue(workflow.contains("MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD"))
+        XCTAssertTrue(workflow.contains("MACOS_NOTARY_APPLE_ID"))
+        XCTAssertTrue(workflow.contains("MACOS_NOTARY_TEAM_ID"))
+        XCTAssertTrue(workflow.contains("MACOS_NOTARY_PASSWORD"))
+        XCTAssertTrue(workflow.contains("xcrun notarytool store-credentials"))
+        XCTAssertTrue(workflow.contains("SIGN_IDENTITY: Developer ID Application"))
+        XCTAssertTrue(workflow.contains("NOTARY_PROFILE: workshop-wallpaper-bridge-notary"))
+        XCTAssertTrue(workflow.contains("REQUIRE_SIGNING: \"1\""))
+        XCTAssertTrue(workflow.contains("REQUIRE_NOTARIZATION: \"1\""))
+    }
+
+    func testPackagingScriptVerifiesNotarizedQuarantinedApp() throws {
+        let script = try String(contentsOfFile: "Scripts/package-app.sh")
+
+        XCTAssertTrue(script.contains("REQUIRE_NOTARIZATION=\"${REQUIRE_NOTARIZATION:-0}\""))
+        XCTAssertTrue(script.contains("verify_gatekeeper_accepts_quarantined_app_from_dmg"))
+        XCTAssertTrue(script.contains("spctl --assess --type execute"))
+        XCTAssertTrue(script.contains("com.apple.quarantine"))
+    }
+
     func testPackagedAppDefaultsToCurrentReleaseVersion() throws {
         let script = try String(contentsOfFile: "Scripts/package-app.sh")
 


### PR DESCRIPTION
## Summary
- Fixes #1 by making public macOS releases require Developer ID signing and notarization instead of shipping unsigned DMGs that Gatekeeper can block after download quarantine is applied.
- Imports the Developer ID certificate in the release workflow, stores notary credentials in a temporary keychain, requires signing/notarization flags, and cleans up the keychain on completion.
- Extends packaging to fail when notarization is requested without credentials and to verify a copied app with `com.apple.quarantine` applied via `spctl --assess --type execute` after stapling.
- Updates English and Korean docs plus regression tests for the release contract.

## Validation
- `swift test`
- `bash -n Scripts/package-app.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow yaml ok"'`\n- `bash Scripts/package-app.sh`\n- `REQUIRE_NOTARIZATION=1 bash Scripts/package-app.sh` fails early with `NOTARY_PROFILE is required when REQUIRE_NOTARIZATION=1.`\n- `xattr -lr "dist/Workshop Wallpaper Bridge.app" "dist/WorkshopWallpaperBridge-macOS-arm64.dmg" | rg "com\\.apple\\.quarantine" || true` produced no quarantine metadata\n- `swift run wwbctl doctor`\n- Independent code review: no security findings\n\n## Release note\nThe live notarization upload path still requires repository secrets: `MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64`, `MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD`, `MACOS_NOTARY_APPLE_ID`, `MACOS_NOTARY_TEAM_ID`, and `MACOS_NOTARY_PASSWORD`. The workflow now refuses to publish release artifacts without them.