### PR TITLE
fix: keep native scene wallpapers visually continuous

### DIFF
--- a/Scripts/scene-frame-diff.swift
+++ b/Scripts/scene-frame-diff.swift
@@ -1,0 +1,431 @@
+#!/usr/bin/env swift
+
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+private struct RGBAImage {
+    let width: Int
+    let height: Int
+    let bytes: [UInt8]
+}
+
+private struct DiffSummary {
+    let width: Int
+    let height: Int
+    let changedPixelCount: Int
+    let totalPixelCount: Int
+    let changedRatio: Double
+    let averageAbsDelta: Double
+    let maxAbsDelta: Int
+    let blackRatioA: Double
+    let blackRatioB: Double
+
+    var text: String {
+        [
+            "width=\(width)",
+            "height=\(height)",
+            "changedPixelCount=\(changedPixelCount)",
+            "totalPixelCount=\(totalPixelCount)",
+            "changedRatio=\(Self.format(changedRatio))",
+            "averageAbsDelta=\(Self.format(averageAbsDelta))",
+            "maxAbsDelta=\(maxAbsDelta)",
+            "blackRatioA=\(Self.format(blackRatioA))",
+            "blackRatioB=\(Self.format(blackRatioB))"
+        ].joined(separator: "\n")
+    }
+
+    var json: String {
+        """
+        {
+          "width": \(width),
+          "height": \(height),
+          "changedPixelCount": \(changedPixelCount),
+          "totalPixelCount": \(totalPixelCount),
+          "changedRatio": \(Self.format(changedRatio)),
+          "averageAbsDelta": \(Self.format(averageAbsDelta)),
+          "maxAbsDelta": \(maxAbsDelta),
+          "blackRatioA": \(Self.format(blackRatioA)),
+          "blackRatioB": \(Self.format(blackRatioB))
+        }
+        """
+    }
+
+    private static func format(_ value: Double) -> String {
+        String(format: "%.6f", value)
+    }
+}
+
+private enum FrameDiffError: Error, CustomStringConvertible {
+    case usage
+    case missingValue(String)
+    case invalidInteger(String)
+    case invalidDouble(String)
+    case invalidMode(String)
+    case unreadableImage(String)
+    case imageDecodeFailed(String)
+    case invalidImageDimensions(width: Int, height: Int)
+    case imageTooLarge(width: Int, height: Int, maximumPixels: Int)
+    case imageByteCountOverflow(width: Int, height: Int)
+    case incompatibleDimensions(aWidth: Int, aHeight: Int, bWidth: Int, bHeight: Int)
+    case couldNotCreateFixture(String)
+    case minChangedPixelsFailed(actual: Int, expected: Int)
+    case maxBlackRatioFailed(actual: Double, maximum: Double)
+
+    var description: String {
+        switch self {
+        case .usage:
+            return """
+            usage:
+              scene-frame-diff.swift <frame-a.png> <frame-b.png> [--min-changed-pixels N] [--max-black-ratio R] [--json]
+              scene-frame-diff.swift --make-fixtures <frame-a.png> <frame-b.png> --mode same|different|black
+            """
+        case .missingValue(let flag):
+            return "missing value for \(flag)"
+        case .invalidInteger(let value):
+            return "invalid integer: \(value)"
+        case .invalidDouble(let value):
+            return "invalid number: \(value)"
+        case .invalidMode(let value):
+            return "invalid fixture mode: \(value)"
+        case .unreadableImage(let path):
+            return "could not read image: \(path)"
+        case .imageDecodeFailed(let path):
+            return "could not decode image pixels: \(path)"
+        case .invalidImageDimensions(let width, let height):
+            return "invalid image dimensions: \(width)x\(height)"
+        case .imageTooLarge(let width, let height, let maximumPixels):
+            return "image \(width)x\(height) exceeds maximum \(maximumPixels) pixels"
+        case .imageByteCountOverflow(let width, let height):
+            return "image \(width)x\(height) byte count overflows Int"
+        case .incompatibleDimensions(let aWidth, let aHeight, let bWidth, let bHeight):
+            return "image sizes differ: \(aWidth)x\(aHeight) vs \(bWidth)x\(bHeight)"
+        case .couldNotCreateFixture(let path):
+            return "could not create fixture image: \(path)"
+        case .minChangedPixelsFailed(let actual, let expected):
+            return "changedPixelCount \(actual) is lower than required minimum \(expected)"
+        case .maxBlackRatioFailed(let actual, let maximum):
+            return "black ratio \(String(format: "%.6f", actual)) exceeds maximum \(String(format: "%.6f", maximum))"
+        }
+    }
+}
+
+private enum FixtureMode: String {
+    case same
+    case different
+    case black
+}
+
+private struct Options {
+    var imageA: String?
+    var imageB: String?
+    var makeFixtures = false
+    var mode: FixtureMode?
+    var minChangedPixels: Int?
+    var maxBlackRatio: Double?
+    var outputJSON = false
+}
+
+private let maximumImagePixels = 18_000_000
+
+private func parseOptions(_ rawArguments: [String]) throws -> Options {
+    var arguments = rawArguments
+    var options = Options()
+    var positional: [String] = []
+
+    while !arguments.isEmpty {
+        let argument = arguments.removeFirst()
+        switch argument {
+        case "--make-fixtures":
+            options.makeFixtures = true
+            guard arguments.count >= 2 else {
+                throw FrameDiffError.missingValue(argument)
+            }
+            positional.append(arguments.removeFirst())
+            positional.append(arguments.removeFirst())
+        case "--mode":
+            guard let value = arguments.first else {
+                throw FrameDiffError.missingValue(argument)
+            }
+            arguments.removeFirst()
+            guard let mode = FixtureMode(rawValue: value) else {
+                throw FrameDiffError.invalidMode(value)
+            }
+            options.mode = mode
+        case "--min-changed-pixels":
+            guard let value = arguments.first else {
+                throw FrameDiffError.missingValue(argument)
+            }
+            arguments.removeFirst()
+            guard let parsed = Int(value), parsed >= 0 else {
+                throw FrameDiffError.invalidInteger(value)
+            }
+            options.minChangedPixels = parsed
+        case "--max-black-ratio":
+            guard let value = arguments.first else {
+                throw FrameDiffError.missingValue(argument)
+            }
+            arguments.removeFirst()
+            guard let parsed = Double(value), parsed >= 0, parsed <= 1 else {
+                throw FrameDiffError.invalidDouble(value)
+            }
+            options.maxBlackRatio = parsed
+        case "--json":
+            options.outputJSON = true
+        default:
+            positional.append(argument)
+        }
+    }
+
+    guard positional.count == 2 else {
+        throw FrameDiffError.usage
+    }
+    options.imageA = positional[0]
+    options.imageB = positional[1]
+
+    if options.makeFixtures, options.mode == nil {
+        throw FrameDiffError.missingValue("--mode")
+    }
+    if !options.makeFixtures, options.mode != nil {
+        throw FrameDiffError.usage
+    }
+
+    return options
+}
+
+private func loadImage(path: String) throws -> RGBAImage {
+    let url = URL(fileURLWithPath: path)
+    guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+        throw FrameDiffError.unreadableImage(path)
+    }
+    guard let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+        throw FrameDiffError.imageDecodeFailed(path)
+    }
+
+    let width = image.width
+    let height = image.height
+    _ = try checkedPixelCount(width: width, height: height)
+    let bytesPerRow = try checkedByteCount(width: width, height: 1)
+    let byteCount = try checkedByteCount(width: width, height: height)
+    var bytes = [UInt8](repeating: 0, count: byteCount)
+    guard let context = CGContext(
+        data: &bytes,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: bytesPerRow,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ) else {
+        throw FrameDiffError.imageDecodeFailed(path)
+    }
+    context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+    return RGBAImage(width: width, height: height, bytes: bytes)
+}
+
+private func checkedPixelCount(width: Int, height: Int) throws -> Int {
+    guard width > 0, height > 0 else {
+        throw FrameDiffError.invalidImageDimensions(width: width, height: height)
+    }
+    let product = width.multipliedReportingOverflow(by: height)
+    guard !product.overflow else {
+        throw FrameDiffError.imageByteCountOverflow(width: width, height: height)
+    }
+    guard product.partialValue <= maximumImagePixels else {
+        throw FrameDiffError.imageTooLarge(width: width, height: height, maximumPixels: maximumImagePixels)
+    }
+    return product.partialValue
+}
+
+private func checkedByteCount(width: Int, height: Int) throws -> Int {
+    let row = width.multipliedReportingOverflow(by: 4)
+    guard !row.overflow else {
+        throw FrameDiffError.imageByteCountOverflow(width: width, height: height)
+    }
+    let total = row.partialValue.multipliedReportingOverflow(by: height)
+    guard !total.overflow else {
+        throw FrameDiffError.imageByteCountOverflow(width: width, height: height)
+    }
+    return total.partialValue
+}
+
+private func diff(_ a: RGBAImage, _ b: RGBAImage) throws -> DiffSummary {
+    guard a.width == b.width, a.height == b.height else {
+        throw FrameDiffError.incompatibleDimensions(
+            aWidth: a.width,
+            aHeight: a.height,
+            bWidth: b.width,
+            bHeight: b.height
+        )
+    }
+
+    let totalPixels = a.width * a.height
+    var changedPixels = 0
+    var totalAbsDelta = 0
+    var maxAbsDelta = 0
+    var blackPixelsA = 0
+    var blackPixelsB = 0
+
+    for pixelIndex in 0..<totalPixels {
+        let offset = pixelIndex * 4
+        let aR = Int(a.bytes[offset])
+        let aG = Int(a.bytes[offset + 1])
+        let aB = Int(a.bytes[offset + 2])
+        let bR = Int(b.bytes[offset])
+        let bG = Int(b.bytes[offset + 1])
+        let bB = Int(b.bytes[offset + 2])
+        let deltaR = abs(aR - bR)
+        let deltaG = abs(aG - bG)
+        let deltaB = abs(aB - bB)
+        let pixelDelta = deltaR + deltaG + deltaB
+        let maxChannelDelta = max(deltaR, deltaG, deltaB)
+
+        if maxChannelDelta > 0 {
+            changedPixels += 1
+        }
+        totalAbsDelta += pixelDelta
+        maxAbsDelta = max(maxAbsDelta, maxChannelDelta)
+
+        if aR < 16, aG < 16, aB < 16 {
+            blackPixelsA += 1
+        }
+        if bR < 16, bG < 16, bB < 16 {
+            blackPixelsB += 1
+        }
+    }
+
+    let denominator = Double(max(totalPixels, 1))
+    return DiffSummary(
+        width: a.width,
+        height: a.height,
+        changedPixelCount: changedPixels,
+        totalPixelCount: totalPixels,
+        changedRatio: Double(changedPixels) / denominator,
+        averageAbsDelta: Double(totalAbsDelta) / (denominator * 3),
+        maxAbsDelta: maxAbsDelta,
+        blackRatioA: Double(blackPixelsA) / denominator,
+        blackRatioB: Double(blackPixelsB) / denominator
+    )
+}
+
+private func writePNG(path: String, width: Int, height: Int, bytes: [UInt8]) throws {
+    let url = URL(fileURLWithPath: path)
+    try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+    var mutableBytes = bytes
+    guard let context = CGContext(
+        data: &mutableBytes,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: width * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ),
+        let image = context.makeImage(),
+        let destination = CGImageDestinationCreateWithURL(
+            url as CFURL,
+            UTType.png.identifier as CFString,
+            1,
+            nil
+        )
+    else {
+        throw FrameDiffError.couldNotCreateFixture(path)
+    }
+    CGImageDestinationAddImage(destination, image, nil)
+    guard CGImageDestinationFinalize(destination) else {
+        throw FrameDiffError.couldNotCreateFixture(path)
+    }
+}
+
+private func fixtureBytes(mode: FixtureMode, variant: Int) -> [UInt8] {
+    switch mode {
+    case .same:
+        return [
+            18, 22, 36, 255, 48, 60, 82, 255, 88, 120, 140, 255, 130, 170, 190, 255,
+            22, 34, 48, 255, 56, 72, 94, 255, 96, 132, 150, 255, 140, 182, 202, 255,
+            30, 42, 58, 255, 64, 82, 104, 255, 108, 144, 162, 255, 150, 194, 214, 255,
+            42, 54, 70, 255, 78, 96, 116, 255, 120, 156, 174, 255, 162, 206, 226, 255
+        ]
+    case .different:
+        let a: [UInt8] = [
+            18, 22, 36, 255, 48, 60, 82, 255, 88, 120, 140, 255, 130, 170, 190, 255,
+            22, 34, 48, 255, 56, 72, 94, 255, 96, 132, 150, 255, 140, 182, 202, 255,
+            30, 42, 58, 255, 64, 82, 104, 255, 108, 144, 162, 255, 150, 194, 214, 255,
+            42, 54, 70, 255, 78, 96, 116, 255, 120, 156, 174, 255, 162, 206, 226, 255
+        ]
+        let b: [UInt8] = [
+            24, 30, 42, 255, 52, 68, 100, 255, 120, 152, 170, 255, 138, 178, 206, 255,
+            28, 40, 54, 255, 72, 92, 118, 255, 112, 154, 176, 255, 148, 194, 222, 255,
+            44, 58, 74, 255, 84, 112, 136, 255, 132, 172, 196, 255, 168, 214, 234, 255,
+            60, 76, 94, 255, 96, 122, 146, 255, 142, 182, 204, 255, 190, 228, 246, 255
+        ]
+        return variant == 0 ? a : b
+    case .black:
+        return [UInt8](repeating: 0, count: 4 * 4 * 4).enumerated().map { index, value in
+            (index + 1).isMultiple(of: 4) ? 255 : value
+        }
+    }
+}
+
+private func makeFixtures(pathA: String, pathB: String, mode: FixtureMode) throws {
+    try writePNG(path: pathA, width: 4, height: 4, bytes: fixtureBytes(mode: mode, variant: 0))
+    try writePNG(path: pathB, width: 4, height: 4, bytes: fixtureBytes(mode: mode, variant: 1))
+}
+
+private func validate(_ summary: DiffSummary, options: Options) throws {
+    if let minChangedPixels = options.minChangedPixels,
+       summary.changedPixelCount < minChangedPixels {
+        throw FrameDiffError.minChangedPixelsFailed(
+            actual: summary.changedPixelCount,
+            expected: minChangedPixels
+        )
+    }
+
+    if let maxBlackRatio = options.maxBlackRatio {
+        let worstBlackRatio = max(summary.blackRatioA, summary.blackRatioB)
+        if worstBlackRatio > maxBlackRatio {
+            throw FrameDiffError.maxBlackRatioFailed(
+                actual: worstBlackRatio,
+                maximum: maxBlackRatio
+            )
+        }
+    }
+}
+
+private func main() throws {
+    let options = try parseOptions(Array(CommandLine.arguments.dropFirst()))
+    guard let imageA = options.imageA, let imageB = options.imageB else {
+        throw FrameDiffError.usage
+    }
+
+    if options.makeFixtures {
+        guard let mode = options.mode else {
+            throw FrameDiffError.missingValue("--mode")
+        }
+        try makeFixtures(pathA: imageA, pathB: imageB, mode: mode)
+        print("fixturesWritten=2")
+        print("mode=\(mode.rawValue)")
+        print("pathA=\(imageA)")
+        print("pathB=\(imageB)")
+        return
+    }
+
+    let summary = try diff(try loadImage(path: imageA), try loadImage(path: imageB))
+    try validate(summary, options: options)
+    print(options.outputJSON ? summary.json : summary.text)
+}
+
+do {
+    try main()
+} catch let error as FrameDiffError {
+    fputs("\(error.description)\n", stderr)
+    exit(2)
+} catch {
+    fputs("\(error)\n", stderr)
+    exit(1)
+}

--- a/Sources/WorkshopWallpaperBridgeApp/SceneTickSource.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/SceneTickSource.swift
@@ -1,0 +1,139 @@
+import AppKit
+import QuartzCore
+
+struct SceneTick: Equatable {
+    let elapsedTime: TimeInterval
+    let frameTime: TimeInterval
+}
+
+struct SceneTickClock {
+    private(set) var elapsedTime: TimeInterval = 0
+    private(set) var frameTime: TimeInterval = 1.0 / 60.0
+    private(set) var isSuspended = false
+    private(set) var isInvalidated = false
+
+    mutating func advance(by delta: TimeInterval) -> SceneTick? {
+        guard !isSuspended, !isInvalidated, delta > 0 else {
+            return nil
+        }
+        frameTime = delta
+        elapsedTime += delta
+        return SceneTick(elapsedTime: elapsedTime, frameTime: frameTime)
+    }
+
+    mutating func suspend() {
+        isSuspended = true
+    }
+
+    mutating func resume() {
+        guard !isInvalidated else {
+            return
+        }
+        isSuspended = false
+    }
+
+    mutating func reset() {
+        elapsedTime = 0
+        frameTime = 1.0 / 60.0
+        isSuspended = false
+    }
+
+    mutating func invalidate() {
+        isInvalidated = true
+        isSuspended = true
+    }
+}
+
+@MainActor
+protocol SceneTickSource: AnyObject {
+    var elapsedTime: TimeInterval { get }
+    var frameTime: TimeInterval { get }
+    var isRunning: Bool { get }
+    var onTick: ((SceneTick) -> Void)? { get set }
+
+    func start()
+    func stop()
+    func suspend()
+    func resume()
+    func reset()
+    func invalidate()
+}
+
+@MainActor
+final class CADisplayLinkSceneTickSource: SceneTickSource {
+    private var clock = SceneTickClock()
+    private var displayLink: CADisplayLink?
+    private var lastTimestamp: TimeInterval?
+
+    var onTick: ((SceneTick) -> Void)?
+
+    var elapsedTime: TimeInterval {
+        clock.elapsedTime
+    }
+
+    var frameTime: TimeInterval {
+        clock.frameTime
+    }
+
+    var isRunning: Bool {
+        displayLink != nil
+    }
+
+    func start() {
+        guard displayLink == nil, !clock.isInvalidated else {
+            return
+        }
+        guard let displayLink = NSScreen.main?.displayLink(
+            target: self,
+            selector: #selector(handleDisplayLink(_:))
+        ) else {
+            return
+        }
+        displayLink.add(to: .main, forMode: .common)
+        self.displayLink = displayLink
+    }
+
+    func stop() {
+        displayLink?.invalidate()
+        displayLink = nil
+        lastTimestamp = nil
+    }
+
+    func suspend() {
+        clock.suspend()
+        displayLink?.isPaused = true
+        lastTimestamp = nil
+    }
+
+    func resume() {
+        clock.resume()
+        lastTimestamp = nil
+        displayLink?.isPaused = false
+    }
+
+    func reset() {
+        stop()
+        clock.reset()
+    }
+
+    func invalidate() {
+        stop()
+        clock.invalidate()
+        onTick = nil
+    }
+
+    @objc
+    private func handleDisplayLink(_ displayLink: CADisplayLink) {
+        let delta: TimeInterval
+        if let lastTimestamp {
+            delta = displayLink.timestamp - lastTimestamp
+        } else {
+            delta = displayLink.duration
+        }
+        self.lastTimestamp = displayLink.timestamp
+        guard let tick = clock.advance(by: delta) else {
+            return
+        }
+        onTick?(tick)
+    }
+}

--- a/Sources/WorkshopWallpaperBridgeApp/SceneWallpaperView.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/SceneWallpaperView.swift
@@ -15,9 +15,7 @@ final class SceneWallpaperView: NSView,
     private var shaderEffectLayers: [ShaderEffectLayer] = []
     private var dynamicTextLayers: [DynamicTextLayer] = []
     private var textRefreshTimer: Timer?
-    private var shaderEffectTimer: Timer?
-    private var shaderEffectElapsedTime: TimeInterval = 0
-    private var shaderEffectResumeTime = CACurrentMediaTime()
+    private let sceneTickSource: SceneTickSource
     private var decodeTask: Task<Void, Never>?
     private var isSuspended = false
     private var isClosed = false
@@ -81,10 +79,20 @@ final class SceneWallpaperView: NSView,
     }
     """)
 
-    init(url: URL, previewURL: URL?, frame: CGRect, displayMode: WallpaperDisplayMode) throws {
+    init(
+        url: URL,
+        previewURL: URL?,
+        frame: CGRect,
+        displayMode: WallpaperDisplayMode,
+        sceneTickSource: SceneTickSource = CADisplayLinkSceneTickSource()
+    ) throws {
         plan = try SceneRenderPlanBuilder().buildLayout(url: url)
         self.displayMode = displayMode
+        self.sceneTickSource = sceneTickSource
         super.init(frame: frame)
+        self.sceneTickSource.onTick = { [weak self] tick in
+            self?.refreshSceneTickDrivenLayers(tick)
+        }
         wantsLayer = true
         layer = CALayer()
         layer?.backgroundColor = NSColor.black.cgColor
@@ -110,17 +118,13 @@ final class SceneWallpaperView: NSView,
         guard suspended != isSuspended else {
             return
         }
-        if suspended {
-            shaderEffectElapsedTime = currentShaderEffectTime()
-        }
         isSuspended = suspended
         setLayerTreePaused(suspended)
         if suspended {
-            shaderEffectTimer?.invalidate()
-            shaderEffectTimer = nil
+            sceneTickSource.suspend()
         } else {
-            shaderEffectResumeTime = CACurrentMediaTime()
-            startShaderEffectTimerIfNeeded()
+            sceneTickSource.resume()
+            startSceneTickSourceIfNeeded()
         }
     }
 
@@ -143,8 +147,7 @@ final class SceneWallpaperView: NSView,
         dynamicTextLayers = []
         textRefreshTimer?.invalidate()
         textRefreshTimer = nil
-        shaderEffectTimer?.invalidate()
-        shaderEffectTimer = nil
+        sceneTickSource.invalidate()
     }
 
     private func configureSceneLayer() {
@@ -200,8 +203,7 @@ final class SceneWallpaperView: NSView,
         dynamicTextLayers = []
         textRefreshTimer?.invalidate()
         textRefreshTimer = nil
-        shaderEffectTimer?.invalidate()
-        shaderEffectTimer = nil
+        sceneTickSource.stop()
         buildLayers()
         layoutScene()
         if isSuspended {
@@ -259,11 +261,12 @@ final class SceneWallpaperView: NSView,
             contentLayer.name = layerPlan.name
             contentLayer.opacity = Float(max(0, min(layerPlan.alpha * opacityMultiplier(for: layerPlan), 1)))
             configure(contentLayer, with: layerPlan)
+            applyOpacityMaskIfAvailable(to: contentLayer, for: layerPlan)
             sceneLayer.addSublayer(contentLayer)
             contentLayers.append(contentLayer)
         }
         configureTextRefreshTimer()
-        startShaderEffectTimerIfNeeded()
+        startSceneTickSourceIfNeeded()
     }
 
     private func buildEffectOnlyShaderLayer(for layerPlan: SceneLayer) -> CALayer? {
@@ -311,25 +314,27 @@ final class SceneWallpaperView: NSView,
     private func configureTextRefreshTimer() {
         textRefreshTimer?.invalidate()
         textRefreshTimer = nil
-        guard !dynamicTextLayers.isEmpty else {
+        guard dynamicTextLayers.contains(where: { $0.scriptEvaluator == nil }) else {
             return
         }
-        let interval = dynamicTextLayers.contains { $0.scriptEvaluator != nil }
-            ? 1.0 / 24.0
-            : 1
-        refreshDynamicTextLayers(frameTime: interval)
+        let interval: TimeInterval = 1
+        refreshDynamicTextLayers(frameTime: interval, includeScripted: false)
         textRefreshTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
             Task { @MainActor in
-                self?.refreshDynamicTextLayers(frameTime: interval)
+                self?.refreshDynamicTextLayers(frameTime: interval, includeScripted: false)
             }
         }
     }
 
-    private func refreshDynamicTextLayers(date: Date = Date(), frameTime: TimeInterval = 1) {
+    private func refreshDynamicTextLayers(
+        date: Date = Date(),
+        frameTime: TimeInterval = 1,
+        includeScripted: Bool = true
+    ) {
         guard !isClosed else {
             return
         }
-        for item in dynamicTextLayers {
+        for item in dynamicTextLayers where includeScripted || item.scriptEvaluator == nil {
             item.layer.string = string(
                 for: item.text,
                 scriptEvaluator: item.scriptEvaluator,
@@ -343,7 +348,7 @@ final class SceneWallpaperView: NSView,
         for text: SceneTextLayer,
         scriptEvaluator: SceneScriptTextEvaluator? = nil,
         date: Date = Date(),
-        frameTime: TimeInterval = 1.0 / 24.0
+        frameTime: TimeInterval = 1.0 / 60.0
     ) -> String {
         let fallback: String
         switch text.dynamicText {
@@ -358,7 +363,7 @@ final class SceneWallpaperView: NSView,
         return scriptEvaluator.string(
             currentValue: fallback,
             date: date,
-            runtime: SceneScriptRuntime(time: currentShaderEffectTime(), frameTime: frameTime)
+            runtime: SceneScriptRuntime(time: currentSceneTime(), frameTime: sceneFrameTime(fallback: frameTime))
         )
     }
 
@@ -464,7 +469,11 @@ final class SceneWallpaperView: NSView,
                 addSpinEffectAnimation(to: layer, effect: effect)
             case .shine:
                 addShineEffectAnimation(to: layer, effect: effect)
-            case .waterFlow, .waterWaves, .waterRipple, .scroll, .opacity:
+            case .pulse:
+                addPulseEffectAnimation(to: layer, effect: effect)
+            case .waterFlow, .waterWaves, .waterRipple, .scroll, .opacity,
+                    .bloom, .blur, .chromaticAberration, .clouds, .godRays,
+                    .localContrast, .materialColor:
                 continue
             }
         }
@@ -507,11 +516,65 @@ final class SceneWallpaperView: NSView,
         layer.add(keyframe, forKey: "scene-effect-shine")
     }
 
+    private func addPulseEffectAnimation(to layer: CALayer, effect: SceneLayerEffectSetting) {
+        let baseOpacity = Double(layer.opacity)
+        guard baseOpacity > 0 else {
+            return
+        }
+        let strength = max(0, min(effect.strength ?? 0.35, 1))
+        let low = max(0, min(baseOpacity * (1 - (strength * 0.45)), 1))
+        let high = max(0, min(baseOpacity * (1 + (strength * 0.25)), 1))
+        let keyframe = CAKeyframeAnimation(keyPath: "opacity")
+        configure(keyframe, duration: Self.layerEffectDuration(for: effect, defaultDuration: 1.8))
+        keyframe.values = [baseOpacity, high, low, high, baseOpacity]
+        keyframe.keyTimes = [0, 0.25, 0.5, 0.75, 1]
+        layer.add(keyframe, forKey: "scene-effect-pulse")
+    }
+
     private func opacityMultiplier(for plan: SceneLayer) -> Double {
         guard let opacity = plan.effectSettings.last(where: { $0.effect == .opacity }) else {
             return 1
         }
         return max(0, min(opacity.strength ?? 1, 1))
+    }
+
+    private func applyOpacityMaskIfAvailable(to contentLayer: CALayer, for layerPlan: SceneLayer) {
+        guard let texturePath = Self.opacityMaskTexturePath(for: layerPlan),
+              let texture = plan.textures[texturePath],
+              let maskLayer = Self.opacityMaskLayer(
+                from: texture,
+                bounds: contentLayer.bounds,
+                contentsScale: contentLayer.contentsScale
+              ) else {
+            return
+        }
+        contentLayer.mask = maskLayer
+    }
+
+    static func opacityMaskTexturePath(for layer: SceneLayer) -> String? {
+        guard !layer.isEffectOnly else {
+            return nil
+        }
+        return layer.effectSettings.first {
+            $0.effect == .opacity && $0.maskReference?.texturePath != nil
+        }?.maskReference?.texturePath
+    }
+
+    static func opacityMaskLayer(
+        from texture: SceneTexture,
+        bounds: CGRect,
+        contentsScale: CGFloat
+    ) -> CALayer? {
+        guard let image = cgImage(from: texture) else {
+            return nil
+        }
+        let maskLayer = CALayer()
+        maskLayer.contents = image
+        maskLayer.contentsGravity = .resize
+        maskLayer.contentsScale = contentsScale
+        maskLayer.bounds = bounds
+        maskLayer.position = CGPoint(x: bounds.midX, y: bounds.midY)
+        return maskLayer
     }
 
     private func configure(_ animation: CAKeyframeAnimation, duration: Double) {
@@ -540,23 +603,30 @@ final class SceneWallpaperView: NSView,
         ))
     }
 
-    private func startShaderEffectTimerIfNeeded() {
-        guard !isClosed, !isSuspended, !shaderEffectLayers.isEmpty, shaderEffectTimer == nil else {
+    private func startSceneTickSourceIfNeeded() {
+        guard !isClosed, !isSuspended, !sceneTickSource.isRunning, needsSceneTickSource else {
             return
         }
-        refreshShaderEffectLayers()
-        shaderEffectTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 24.0, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.refreshShaderEffectLayers()
-            }
-        }
+        refreshSceneTickDrivenLayers(SceneTick(
+            elapsedTime: currentSceneTime(),
+            frameTime: sceneFrameTime(fallback: 1.0 / 60.0)
+        ))
+        sceneTickSource.start()
     }
 
-    private func refreshShaderEffectLayers() {
+    private var needsSceneTickSource: Bool {
+        !shaderEffectLayers.isEmpty || dynamicTextLayers.contains { $0.scriptEvaluator != nil }
+    }
+
+    private func refreshSceneTickDrivenLayers(_ tick: SceneTick) {
+        refreshShaderEffectLayers(time: tick.elapsedTime)
+        refreshDynamicTextLayers(frameTime: tick.frameTime)
+    }
+
+    private func refreshShaderEffectLayers(time: TimeInterval) {
         guard !isClosed, !isSuspended else {
             return
         }
-        let time = currentShaderEffectTime()
         for item in shaderEffectLayers {
             guard let image = Self.renderShaderEffects(
                 baseImage: item.baseImage,
@@ -571,29 +641,19 @@ final class SceneWallpaperView: NSView,
     }
 
     private func resetShaderEffectClock() {
-        shaderEffectElapsedTime = 0
-        shaderEffectResumeTime = CACurrentMediaTime()
+        sceneTickSource.reset()
     }
 
-    private func currentShaderEffectTime() -> TimeInterval {
-        Self.shaderEffectTime(
-            elapsedTime: shaderEffectElapsedTime,
-            resumeTime: shaderEffectResumeTime,
-            now: CACurrentMediaTime(),
-            isSuspended: isSuspended
-        )
+    private func currentSceneTime() -> TimeInterval {
+        sceneTickSource.elapsedTime
     }
 
-    nonisolated static func shaderEffectTime(
-        elapsedTime: TimeInterval,
-        resumeTime: TimeInterval,
-        now: TimeInterval,
-        isSuspended: Bool
-    ) -> TimeInterval {
-        if isSuspended {
-            return elapsedTime
+    private func sceneFrameTime(fallback: TimeInterval) -> TimeInterval {
+        let frameTime = sceneTickSource.frameTime
+        guard frameTime > 0 else {
+            return fallback
         }
-        return elapsedTime + max(0, now - resumeTime)
+        return frameTime
     }
 
     private static func renderShaderEffects(
@@ -609,7 +669,19 @@ final class SceneWallpaperView: NSView,
                 image = applyWaterWaves(to: image, effect: effect, time: time) ?? image
             case .scroll:
                 image = applyScroll(to: image, effect: effect, time: time) ?? image
-            case .shake, .spin, .shine, .opacity:
+            case .bloom:
+                image = applyBloom(to: image, effect: effect) ?? image
+            case .blur:
+                image = applyBlur(to: image, effect: effect) ?? image
+            case .chromaticAberration:
+                image = applyChromaticAberration(to: image, effect: effect, time: time) ?? image
+            case .godRays:
+                image = applyGodRays(to: image, effect: effect) ?? image
+            case .localContrast:
+                image = applyLocalContrast(to: image, effect: effect) ?? image
+            case .materialColor:
+                image = applyMaterialColor(to: image, effect: effect) ?? image
+            case .shake, .spin, .shine, .opacity, .pulse, .clouds:
                 continue
             }
         }
@@ -621,9 +693,11 @@ final class SceneWallpaperView: NSView,
     ) -> [SceneLayerEffectSetting] {
         effects.filter { setting in
             switch setting.effect {
-            case .waterFlow, .waterWaves, .waterRipple, .scroll:
+            case .waterFlow, .waterWaves, .waterRipple, .scroll,
+                    .bloom, .blur, .chromaticAberration, .godRays,
+                    .localContrast, .materialColor:
                 return true
-            case .shake, .spin, .shine, .opacity:
+            case .shake, .spin, .shine, .opacity, .pulse, .clouds:
                 return false
             }
         }
@@ -650,9 +724,32 @@ final class SceneWallpaperView: NSView,
         return context.makeImage()
     }
 
+    nonisolated private static let maximumBitmapDimension = 16_384
+    nonisolated private static let maximumBitmapPixels = 18_000_000
+
+    nonisolated static func isSafeBitmapSize(_ size: CGSize) -> Bool {
+        guard size.width.isFinite, size.height.isFinite else {
+            return false
+        }
+        let widthValue = ceil(abs(size.width))
+        let heightValue = ceil(abs(size.height))
+        guard widthValue >= 1,
+              heightValue >= 1,
+              widthValue <= CGFloat(maximumBitmapDimension),
+              heightValue <= CGFloat(maximumBitmapDimension) else {
+            return false
+        }
+        let width = Int(widthValue)
+        let height = Int(heightValue)
+        return width <= maximumBitmapPixels / height
+    }
+
     private static func bitmapContext(size: CGSize) -> CGContext? {
-        let width = Int(max(1, ceil(size.width)))
-        let height = Int(max(1, ceil(size.height)))
+        guard isSafeBitmapSize(size) else {
+            return nil
+        }
+        let width = Int(max(1, ceil(abs(size.width))))
+        let height = Int(max(1, ceil(abs(size.height))))
         return CGContext(
             data: nil,
             width: width,
@@ -666,9 +763,11 @@ final class SceneWallpaperView: NSView,
 
     nonisolated static func isLayerAnimatedEffect(_ effect: SceneLayerEffect) -> Bool {
         switch effect {
-        case .shake, .spin, .shine:
+        case .shake, .spin, .shine, .pulse:
             return true
-        case .waterFlow, .waterWaves, .waterRipple, .scroll, .opacity:
+        case .waterFlow, .waterWaves, .waterRipple, .scroll, .opacity,
+                .bloom, .blur, .chromaticAberration, .clouds, .godRays,
+                .localContrast, .materialColor:
             return false
         }
     }
@@ -688,7 +787,11 @@ final class SceneWallpaperView: NSView,
             return !hasAlphaAnimation
         case .shake:
             return true
-        case .waterFlow, .waterWaves, .waterRipple, .scroll, .opacity:
+        case .pulse:
+            return !hasAlphaAnimation
+        case .waterFlow, .waterWaves, .waterRipple, .scroll, .opacity,
+                .bloom, .blur, .chromaticAberration, .clouds, .godRays,
+                .localContrast, .materialColor:
             return false
         }
     }
@@ -770,6 +873,70 @@ final class SceneWallpaperView: NSView,
                 CIVector(x: extent.origin.x, y: extent.origin.y, z: extent.width, w: extent.height)
             ]
         )
+    }
+
+    private static func applyBloom(to image: CIImage, effect: SceneLayerEffectSetting) -> CIImage? {
+        image.applyingFilter("CIBloom", parameters: [
+            kCIInputRadiusKey: max(1, min((effect.scale ?? 12) * 0.35, 24)),
+            kCIInputIntensityKey: max(0.05, min(effect.strength ?? 0.35, 1.2))
+        ]).cropped(to: image.extent)
+    }
+
+    private static func applyBlur(to image: CIImage, effect: SceneLayerEffectSetting) -> CIImage? {
+        image.applyingFilter("CIGaussianBlur", parameters: [
+            kCIInputRadiusKey: max(0.2, min(effect.strength ?? effect.scale ?? 2, 12))
+        ]).cropped(to: image.extent)
+    }
+
+    private static func applyChromaticAberration(
+        to image: CIImage,
+        effect: SceneLayerEffectSetting,
+        time: Double
+    ) -> CIImage? {
+        let strength = max(0.5, min((effect.strength ?? 0.025) * 64, 8))
+        let phase = sin(time * max(0.25, abs(effect.speed ?? 0.6)))
+        let red = image
+            .transformed(by: CGAffineTransform(translationX: strength, y: phase * strength * 0.25))
+            .applyingFilter("CIColorMatrix", parameters: [
+                "inputRVector": CIVector(x: 1, y: 0, z: 0, w: 0),
+                "inputGVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+                "inputBVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+                "inputAVector": CIVector(x: 0, y: 0, z: 0, w: 1)
+            ])
+        let cyan = image
+            .transformed(by: CGAffineTransform(translationX: -strength, y: -phase * strength * 0.25))
+            .applyingFilter("CIColorMatrix", parameters: [
+                "inputRVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+                "inputGVector": CIVector(x: 0, y: 1, z: 0, w: 0),
+                "inputBVector": CIVector(x: 0, y: 0, z: 1, w: 0),
+                "inputAVector": CIVector(x: 0, y: 0, z: 0, w: 1)
+            ])
+        return red.composited(over: cyan).cropped(to: image.extent)
+    }
+
+    private static func applyGodRays(to image: CIImage, effect: SceneLayerEffectSetting) -> CIImage? {
+        let rays = image.applyingFilter("CIRadialGradient", parameters: [
+            "inputCenter": CIVector(x: image.extent.midX, y: image.extent.maxY),
+            "inputRadius0": max(20, min(image.extent.width, image.extent.height) * 0.06),
+            "inputRadius1": max(image.extent.width, image.extent.height) * 0.75,
+            "inputColor0": CIColor(red: 1, green: 0.96, blue: 0.72, alpha: max(0.04, min(effect.strength ?? 0.16, 0.45))),
+            "inputColor1": CIColor(red: 1, green: 0.96, blue: 0.72, alpha: 0)
+        ]).cropped(to: image.extent)
+        return rays.composited(over: image).cropped(to: image.extent)
+    }
+
+    private static func applyLocalContrast(to image: CIImage, effect: SceneLayerEffectSetting) -> CIImage? {
+        image.applyingFilter("CIColorControls", parameters: [
+            kCIInputSaturationKey: 1 + max(0, min(effect.strength ?? 0.08, 0.35)),
+            kCIInputContrastKey: 1 + max(0, min(effect.strength ?? 0.12, 0.45))
+        ])
+    }
+
+    private static func applyMaterialColor(to image: CIImage, effect: SceneLayerEffectSetting) -> CIImage? {
+        image.applyingFilter("CIColorControls", parameters: [
+            kCIInputSaturationKey: max(0.75, min(1 + (effect.strength ?? 0.08), 1.35)),
+            kCIInputBrightnessKey: max(-0.08, min((effect.strength ?? 0.04) * 0.12, 0.08))
+        ])
     }
 
     nonisolated static func scrollAxisSpeeds(for effect: SceneLayerEffectSetting) -> (x: Double, y: Double) {

--- a/Sources/WorkshopWallpaperBridgeApp/WallpaperPlayer.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/WallpaperPlayer.swift
@@ -256,21 +256,8 @@ enum WallpaperScreenFrames {
         screens.map { wallpaperFrame(screenFrame: $0.frame, visibleFrame: $0.visibleFrame) }
     }
 
-    static func wallpaperFrame(screenFrame: CGRect, visibleFrame: CGRect) -> CGRect {
-        guard screenFrame.width > 0, screenFrame.height > 0,
-              visibleFrame.width > 0, visibleFrame.height > 0 else {
-            return screenFrame
-        }
-        let menuBarBottom = min(screenFrame.maxY, max(screenFrame.minY, visibleFrame.maxY))
-        guard menuBarBottom > screenFrame.minY else {
-            return screenFrame
-        }
-        return CGRect(
-            x: screenFrame.minX,
-            y: screenFrame.minY,
-            width: screenFrame.width,
-            height: menuBarBottom - screenFrame.minY
-        )
+    static func wallpaperFrame(screenFrame: CGRect, visibleFrame _: CGRect) -> CGRect {
+        screenFrame
     }
 
     static func shouldReopenWindows(previous: [CGRect], current: [CGRect]) -> Bool {
@@ -313,7 +300,8 @@ private final class WallpaperWindow {
         window.isReleasedWhenClosed = false
         window.animationBehavior = .none
         window.isExcludedFromWindowsMenu = true
-        window.backgroundColor = .black
+        window.isOpaque = false
+        window.backgroundColor = .clear
         window.contentView = content
     }
 

--- a/Sources/WorkshopWallpaperCore/SceneRenderPlan.swift
+++ b/Sources/WorkshopWallpaperCore/SceneRenderPlan.swift
@@ -188,6 +188,24 @@ public enum SceneLayerEffect: String, Equatable, Sendable {
     case spin
     case shine
     case opacity
+    case bloom
+    case blur
+    case chromaticAberration
+    case clouds
+    case godRays
+    case localContrast
+    case materialColor
+    case pulse
+}
+
+public struct SceneEffectMaskReference: Equatable, Sendable {
+    public let source: String
+    public let texturePath: String?
+
+    public init(source: String, texturePath: String? = nil) {
+        self.source = source
+        self.texturePath = texturePath
+    }
 }
 
 public struct SceneLayerEffectSetting: Equatable, Sendable {
@@ -200,6 +218,7 @@ public struct SceneLayerEffectSetting: Equatable, Sendable {
     public let perspective: Double?
     public let direction: SceneVector3?
     public let usesMask: Bool
+    public let maskReference: SceneEffectMaskReference?
 
     public init(
         effect: SceneLayerEffect,
@@ -210,7 +229,8 @@ public struct SceneLayerEffectSetting: Equatable, Sendable {
         scale: Double? = nil,
         perspective: Double? = nil,
         direction: SceneVector3? = nil,
-        usesMask: Bool = false
+        usesMask: Bool = false,
+        maskReference: SceneEffectMaskReference? = nil
     ) {
         self.effect = effect
         self.speed = speed
@@ -220,7 +240,8 @@ public struct SceneLayerEffectSetting: Equatable, Sendable {
         self.scale = scale
         self.perspective = perspective
         self.direction = direction
-        self.usesMask = usesMask
+        self.usesMask = usesMask || maskReference != nil
+        self.maskReference = maskReference
     }
 }
 
@@ -361,6 +382,7 @@ public struct SceneRenderPlanBuilder: Sendable {
                     }
                     layers.append(Self.layer(
                         from: object,
+                        package: package,
                         texturePath: texturePath,
                         text: nil,
                         texture: texture,
@@ -370,6 +392,7 @@ public struct SceneRenderPlanBuilder: Sendable {
                 } else if Self.isEffectOnlyImageLayer(imagePath: imagePath, object: object) {
                     layers.append(Self.layer(
                         from: object,
+                        package: package,
                         texturePath: "",
                         text: nil,
                         texture: nil,
@@ -380,6 +403,7 @@ public struct SceneRenderPlanBuilder: Sendable {
             } else if let text = Self.textLayer(from: object) {
                 layers.append(Self.layer(
                     from: object,
+                    package: package,
                     texturePath: "",
                     text: text,
                     texture: nil,
@@ -394,6 +418,9 @@ public struct SceneRenderPlanBuilder: Sendable {
 
         guard !layers.isEmpty else {
             throw SceneRenderPlanError.noRenderableLayers
+        }
+        if decodeTextures {
+            try Self.decodeMaskTextures(in: layers, package: package, textures: &textures)
         }
         return SceneRenderPlan(
             canvasSize: canvasSize,
@@ -470,6 +497,7 @@ public struct SceneRenderPlanBuilder: Sendable {
 
     private static func layer(
         from object: [String: Any],
+        package: ScenePackage,
         texturePath: String,
         text: SceneTextLayer?,
         texture: SceneTexture?,
@@ -488,7 +516,7 @@ public struct SceneRenderPlanBuilder: Sendable {
             width: texture.map { Double($0.width) } ?? canvasSize.width,
             height: texture.map { Double($0.height) } ?? canvasSize.height
         )
-        let layerEffectSettings = effectSettings(from: object)
+        let layerEffectSettings = effectSettings(from: object, package: package)
         return SceneLayer(
             id: intValue(object["id"]) ?? 0,
             name: stringValue(object["name"]) ?? stringValue(object["id"]) ?? texturePath,
@@ -622,7 +650,7 @@ public struct SceneRenderPlanBuilder: Sendable {
         ))
     }
 
-    private static func effectSettings(from object: [String: Any]) -> [SceneLayerEffectSetting] {
+    private static func effectSettings(from object: [String: Any], package: ScenePackage? = nil) -> [SceneLayerEffectSetting] {
         guard let rawEffects = object["effects"] as? [[String: Any]] else {
             return []
         }
@@ -648,6 +676,22 @@ public struct SceneRenderPlanBuilder: Sendable {
                 effect = .shine
             } else if file.contains("opacity") {
                 effect = .opacity
+            } else if file.contains("bloom") {
+                effect = .bloom
+            } else if file.contains("blur") {
+                effect = .blur
+            } else if file.contains("chromatic") || file.contains("aberration") {
+                effect = .chromaticAberration
+            } else if file.contains("cloud") {
+                effect = .clouds
+            } else if file.contains("godray") || file.contains("god-ray") || file.contains("god_ray") {
+                effect = .godRays
+            } else if file.contains("localcontrast") || file.contains("local-contrast") || file.contains("local_contrast") {
+                effect = .localContrast
+            } else if file.contains("materialcolor") || file.contains("material-color") || file.contains("material_color") {
+                effect = .materialColor
+            } else if file.contains("pulse") {
+                effect = .pulse
             } else {
                 effect = nil
             }
@@ -655,6 +699,7 @@ public struct SceneRenderPlanBuilder: Sendable {
                 let constants = constantShaderValues(from: rawEffect)
                 let speedX = doubleValue(constants["speedx"])
                 let speedY = doubleValue(constants["speedy"])
+                let maskReference = maskReference(in: rawEffect, package: package)
                 settings.append(SceneLayerEffectSetting(
                     effect: effect,
                     speed: firstNonZeroDouble(
@@ -678,11 +723,33 @@ public struct SceneRenderPlanBuilder: Sendable {
                         ?? vectorValue(constants["scrolldirection"])
                         ?? directionVector(fromAngle: doubleValue(constants["direction"]))
                         ?? directionVector(fromAngle: doubleValue(constants["scrolldirection"])),
-                    usesMask: containsMaskReference(rawEffect, depth: 0)
+                    usesMask: containsMaskReference(rawEffect, depth: 0),
+                    maskReference: maskReference
                 ))
             }
         }
         return settings
+    }
+
+    private static func decodeMaskTextures(
+        in layers: [SceneLayer],
+        package: ScenePackage,
+        textures: inout [String: SceneTexture]
+    ) throws {
+        let maskTexturePaths = Set(layers.flatMap { layer in
+            layer.effectSettings.compactMap { $0.maskReference?.texturePath }
+        })
+        let decoder = SceneTextureDecoder()
+        for texturePath in maskTexturePaths where textures[texturePath] == nil {
+            guard let data = package.data(forPath: texturePath) else {
+                continue
+            }
+            do {
+                textures[texturePath] = try decoder.decode(data: data)
+            } catch {
+                continue
+            }
+        }
     }
 
     private static func firstNonZeroDouble(_ values: Double?...) -> Double? {
@@ -700,6 +767,81 @@ public struct SceneRenderPlanBuilder: Sendable {
         var values: [String: Any] = [:]
         collectConstantShaderValues(effect, into: &values, depth: 0)
         return values
+    }
+
+    private static func maskReference(in effect: [String: Any], package: ScenePackage?) -> SceneEffectMaskReference? {
+        guard let source = firstMaskReferenceSource(in: effect, depth: 0) else {
+            return nil
+        }
+        return SceneEffectMaskReference(
+            source: source,
+            texturePath: resolvedTexturePath(for: source, package: package)
+        )
+    }
+
+    private static func resolvedTexturePath(for source: String, package: ScenePackage?) -> String? {
+        guard let package else {
+            return nil
+        }
+        return textureCandidates(for: source).first { package.entry(named: $0) != nil }
+    }
+
+    private static func firstMaskReferenceSource(in value: Any, depth: Int) -> String? {
+        guard depth <= 64 else {
+            return nil
+        }
+        if let dict = value as? [String: Any] {
+            for (key, child) in dict where key.lowercased().contains("mask") {
+                if let childSource = firstString(in: child, depth: depth + 1) {
+                    return childSource
+                }
+                return key
+            }
+            for child in dict.values {
+                if let source = firstMaskReferenceSource(in: child, depth: depth + 1) {
+                    return source
+                }
+            }
+            return nil
+        }
+        if let array = value as? [Any] {
+            for child in array {
+                if let source = firstMaskReferenceSource(in: child, depth: depth + 1) {
+                    return source
+                }
+            }
+            return nil
+        }
+        guard let string = stringValue(value),
+              string.lowercased().contains("mask") else {
+            return nil
+        }
+        return string
+    }
+
+    private static func firstString(in value: Any, depth: Int) -> String? {
+        guard depth <= 64 else {
+            return nil
+        }
+        if let string = stringValue(value), !string.isEmpty {
+            return string
+        }
+        if let array = value as? [Any] {
+            for child in array {
+                if let source = firstString(in: child, depth: depth + 1) {
+                    return source
+                }
+            }
+            return nil
+        }
+        if let dict = value as? [String: Any] {
+            for child in dict.values {
+                if let source = firstString(in: child, depth: depth + 1) {
+                    return source
+                }
+            }
+        }
+        return nil
     }
 
     private static func collectConstantShaderValues(_ value: Any, into values: inout [String: Any], depth: Int) {

--- a/Sources/WorkshopWallpaperCore/SceneRuntimeFeatures.swift
+++ b/Sources/WorkshopWallpaperCore/SceneRuntimeFeatures.swift
@@ -41,6 +41,7 @@ public struct SceneRuntimeFeatures: Codable, Equatable, Sendable {
     public let requiresVideoTextureRuntime: Bool
     public let requiresShaderPipeline: Bool
     public let requiresAudioAnalysis: Bool
+    public let requiresMaskedEffectComposition: Bool
 
     init(
         layers: [SceneRuntimeLayerFeature],
@@ -57,7 +58,8 @@ public struct SceneRuntimeFeatures: Codable, Equatable, Sendable {
         requiresModelRuntime: Bool,
         requiresVideoTextureRuntime: Bool,
         requiresShaderPipeline: Bool,
-        requiresAudioAnalysis: Bool
+        requiresAudioAnalysis: Bool,
+        requiresMaskedEffectComposition: Bool
     ) {
         self.layers = layers
         self.materialFiles = materialFiles
@@ -74,6 +76,7 @@ public struct SceneRuntimeFeatures: Codable, Equatable, Sendable {
         self.requiresVideoTextureRuntime = requiresVideoTextureRuntime
         self.requiresShaderPipeline = requiresShaderPipeline
         self.requiresAudioAnalysis = requiresAudioAnalysis
+        self.requiresMaskedEffectComposition = requiresMaskedEffectComposition
     }
 
     public var requiresEngineRenderer: Bool {
@@ -84,6 +87,7 @@ public struct SceneRuntimeFeatures: Codable, Equatable, Sendable {
             || requiresVideoTextureRuntime
             || requiresShaderPipeline
             || requiresAudioAnalysis
+            || requiresMaskedEffectComposition
     }
 
     public var runtimeGaps: [String] {
@@ -108,6 +112,9 @@ public struct SceneRuntimeFeatures: Codable, Equatable, Sendable {
         }
         if requiresVideoTextureRuntime {
             gaps.append("video-texture-runtime")
+        }
+        if requiresMaskedEffectComposition {
+            gaps.append("masked-effect-composition")
         }
         return gaps
     }
@@ -135,6 +142,7 @@ public struct SceneRuntimeFeatures: Codable, Equatable, Sendable {
         case requiresVideoTextureRuntime
         case requiresShaderPipeline
         case requiresAudioAnalysis
+        case requiresMaskedEffectComposition
         case requiresEngineRenderer
         case runtimeGaps
         case userFacingSummary
@@ -157,6 +165,8 @@ public struct SceneRuntimeFeatures: Codable, Equatable, Sendable {
         requiresVideoTextureRuntime = try container.decode(Bool.self, forKey: .requiresVideoTextureRuntime)
         requiresShaderPipeline = try container.decode(Bool.self, forKey: .requiresShaderPipeline)
         requiresAudioAnalysis = try container.decode(Bool.self, forKey: .requiresAudioAnalysis)
+        requiresMaskedEffectComposition = try container
+            .decodeIfPresent(Bool.self, forKey: .requiresMaskedEffectComposition) ?? false
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -176,6 +186,7 @@ public struct SceneRuntimeFeatures: Codable, Equatable, Sendable {
         try container.encode(requiresVideoTextureRuntime, forKey: .requiresVideoTextureRuntime)
         try container.encode(requiresShaderPipeline, forKey: .requiresShaderPipeline)
         try container.encode(requiresAudioAnalysis, forKey: .requiresAudioAnalysis)
+        try container.encode(requiresMaskedEffectComposition, forKey: .requiresMaskedEffectComposition)
         try container.encode(requiresEngineRenderer, forKey: .requiresEngineRenderer)
         try container.encode(runtimeGaps, forKey: .runtimeGaps)
         try container.encode(userFacingSummary, forKey: .userFacingSummary)
@@ -225,7 +236,8 @@ public struct SceneRuntimeFeatureAnalyzer: Sendable {
             requiresModelRuntime: layers.contains { $0.kind == "model" },
             requiresVideoTextureRuntime: !videoFiles.isEmpty,
             requiresShaderPipeline: !shaderFiles.isEmpty || layers.contains { !$0.effectFiles.isEmpty },
-            requiresAudioAnalysis: hasAudioUniforms || Self.containsAudioScript(in: objects)
+            requiresAudioAnalysis: hasAudioUniforms || Self.containsAudioScript(in: objects),
+            requiresMaskedEffectComposition: Self.containsEffectMaskReference(in: objects)
         )
     }
 
@@ -359,6 +371,39 @@ public struct SceneRuntimeFeatureAnalyzer: Sendable {
                     || source.contains("audio")
             }
         }
+    }
+
+    private static func containsEffectMaskReference(in objects: [[String: Any]]) -> Bool {
+        objects.contains { object in
+            guard let effects = object["effects"] as? [[String: Any]] else {
+                return false
+            }
+            return effects.contains(where: effectContainsMaskReference)
+        }
+    }
+
+    private static func effectContainsMaskReference(_ effect: [String: Any]) -> Bool {
+        if let mask = stringValue(effect["mask"]), isLikelyMaskTextureReference(mask) {
+            return true
+        }
+        guard let passes = effect["passes"] as? [[String: Any]] else {
+            return false
+        }
+        return passes.contains { pass in
+            guard let textures = pass["textures"] as? [Any] else {
+                return false
+            }
+            return textures.dropFirst().contains { texture in
+                guard let texture = stringValue(texture) else {
+                    return false
+                }
+                return isLikelyMaskTextureReference(texture)
+            }
+        }
+    }
+
+    private static func isLikelyMaskTextureReference(_ value: String) -> Bool {
+        value.lowercased().contains("mask")
     }
 
     private static func scriptSource(in value: Any, depth: Int = 0) -> [String] {

--- a/Sources/wwbctl/main.swift
+++ b/Sources/wwbctl/main.swift
@@ -155,7 +155,8 @@ struct WWBCtl {
                     scale: $0.scale,
                     perspective: $0.perspective,
                     direction: $0.direction.map(SceneRenderVectorInfo.init),
-                    usesMask: $0.usesMask
+                    usesMask: $0.usesMask,
+                    maskReference: $0.maskReference.map(SceneRenderMaskReferenceInfo.init)
                 )
             }
         )
@@ -237,7 +238,8 @@ struct WWBCtl {
                     scale: $0.scale,
                     perspective: $0.perspective,
                     direction: $0.direction.map(SceneRenderVectorInfo.init),
-                    usesMask: $0.usesMask
+                    usesMask: $0.usesMask,
+                    maskReference: $0.maskReference.map(SceneRenderMaskReferenceInfo.init)
                 )
             }
         }
@@ -319,6 +321,17 @@ struct WWBCtl {
         let perspective: Double?
         let direction: SceneRenderVectorInfo?
         let usesMask: Bool
+        let maskReference: SceneRenderMaskReferenceInfo?
+    }
+
+    private struct SceneRenderMaskReferenceInfo: Codable {
+        let source: String
+        let texturePath: String?
+
+        init(_ reference: SceneEffectMaskReference) {
+            source = reference.source
+            texturePath = reference.texturePath
+        }
     }
 
     private static func doctor() throws {

--- a/Tests/WorkshopWallpaperBridgeAppTests/SceneWallpaperMaskTests.swift
+++ b/Tests/WorkshopWallpaperBridgeAppTests/SceneWallpaperMaskTests.swift
@@ -1,0 +1,126 @@
+import QuartzCore
+import XCTest
+import WorkshopWallpaperCore
+@testable import WorkshopWallpaperBridgeApp
+
+@MainActor
+final class SceneWallpaperMaskTests: XCTestCase {
+    func testSceneWallpaperAppliesDecodedOpacityMaskToImageLayer() throws {
+        // Given
+        let layer = Self.layer(
+            isEffectOnly: false,
+            effectSettings: [
+                SceneLayerEffectSetting(
+                    effect: .opacity,
+                    maskReference: SceneEffectMaskReference(
+                        source: "masks/fish-mask",
+                        texturePath: "masks/fish-mask.tex"
+                    )
+                )
+            ]
+        )
+        let texture = SceneTexture(
+            width: 1,
+            height: 1,
+            storage: .rgba(width: 1, height: 1, data: Data([255, 255, 255, 255]))
+        )
+
+        // When
+        let maskPath = SceneWallpaperView.opacityMaskTexturePath(for: layer)
+        let maskLayer = SceneWallpaperView.opacityMaskLayer(
+            from: texture,
+            bounds: CGRect(x: 0, y: 0, width: 320, height: 180),
+            contentsScale: 2
+        )
+
+        // Then
+        XCTAssertEqual(maskPath, "masks/fish-mask.tex")
+        let resolvedMaskLayer = try XCTUnwrap(maskLayer)
+        XCTAssertNotNil(resolvedMaskLayer.contents)
+        XCTAssertEqual(resolvedMaskLayer.bounds, CGRect(x: 0, y: 0, width: 320, height: 180))
+        XCTAssertEqual(resolvedMaskLayer.position, CGPoint(x: 160, y: 90))
+
+        let source = try String(contentsOfFile: "Sources/WorkshopWallpaperBridgeApp/SceneWallpaperView.swift")
+        XCTAssertTrue(source.contains("contentLayer.mask = maskLayer"))
+    }
+
+    func testSceneWallpaperLeavesUnresolvedMaskStaticAndDiagnosticOnly() {
+        // Given
+        let unresolved = Self.layer(
+            isEffectOnly: false,
+            effectSettings: [
+                SceneLayerEffectSetting(
+                    effect: .opacity,
+                    maskReference: SceneEffectMaskReference(source: "masks/missing-mask", texturePath: nil)
+                )
+            ]
+        )
+        let effectOnly = Self.layer(
+            isEffectOnly: true,
+            effectSettings: [
+                SceneLayerEffectSetting(
+                    effect: .opacity,
+                    maskReference: SceneEffectMaskReference(
+                        source: "masks/effect-only-mask",
+                        texturePath: "masks/effect-only-mask.tex"
+                    )
+                )
+            ]
+        )
+        let nonOpacityMask = Self.layer(
+            isEffectOnly: false,
+            effectSettings: [
+                SceneLayerEffectSetting(
+                    effect: .waterWaves,
+                    maskReference: SceneEffectMaskReference(
+                        source: "masks/waves-mask",
+                        texturePath: "masks/waves-mask.tex"
+                    )
+                )
+            ]
+        )
+
+        // Then
+        XCTAssertNil(SceneWallpaperView.opacityMaskTexturePath(for: unresolved))
+        XCTAssertNil(SceneWallpaperView.opacityMaskTexturePath(for: effectOnly))
+        XCTAssertNil(SceneWallpaperView.opacityMaskTexturePath(for: nonOpacityMask))
+    }
+
+    func testSceneWallpaperDoesNotAdvertiseCloudsUntilPixelsActuallyChange() {
+        // Given
+        let effects = [SceneLayerEffectSetting(effect: .clouds)]
+
+        // When
+        let renderable = SceneWallpaperView.shaderRenderableEffects(from: effects).map(\.effect)
+
+        // Then
+        XCTAssertFalse(renderable.contains(.clouds))
+    }
+
+    func testSceneWallpaperRejectsOversizedEffectOnlyBitmapSizes() {
+        // Then
+        XCTAssertTrue(SceneWallpaperView.isSafeBitmapSize(CGSize(width: 4096, height: 4096)))
+        XCTAssertFalse(SceneWallpaperView.isSafeBitmapSize(CGSize(width: 100_000, height: 100_000)))
+        XCTAssertFalse(SceneWallpaperView.isSafeBitmapSize(CGSize(width: CGFloat.infinity, height: 100)))
+        XCTAssertFalse(SceneWallpaperView.isSafeBitmapSize(CGSize(width: 100, height: CGFloat.nan)))
+    }
+
+    private static func layer(
+        isEffectOnly: Bool,
+        effectSettings: [SceneLayerEffectSetting]
+    ) -> SceneLayer {
+        SceneLayer(
+            id: 1,
+            name: "Layer",
+            texturePath: "materials/layer.tex",
+            effects: effectSettings.map(\.effect),
+            effectSettings: effectSettings,
+            isEffectOnly: isEffectOnly,
+            origin: SceneVector3(x: 0, y: 0, z: 0),
+            size: SceneSize(width: 320, height: 180),
+            scale: SceneVector3(x: 1, y: 1, z: 1),
+            alpha: 1,
+            originAnimation: nil
+        )
+    }
+}

--- a/Tests/WorkshopWallpaperBridgeAppTests/WallpaperPlayerSuspensionTests.swift
+++ b/Tests/WorkshopWallpaperBridgeAppTests/WallpaperPlayerSuspensionTests.swift
@@ -136,7 +136,7 @@ final class WallpaperPlayerSuspensionTests: XCTestCase {
         XCTAssertTrue(WallpaperScreenFrames.shouldReopenWindows(previous: previous, current: current))
     }
 
-    func testWallpaperWindowFrameAvoidsMenuBarButKeepsDockArea() {
+    func testWallpaperWindowFrameExtendsBehindMenuBarAndDockForContinuousBackdrop() {
         // Given
         let screenFrame = CGRect(x: 0, y: 0, width: 1470, height: 956)
         let visibleFrame = CGRect(x: 0, y: 80, width: 1470, height: 846)
@@ -145,7 +145,21 @@ final class WallpaperPlayerSuspensionTests: XCTestCase {
         let frame = WallpaperScreenFrames.wallpaperFrame(screenFrame: screenFrame, visibleFrame: visibleFrame)
 
         // Then
-        XCTAssertEqual(frame, CGRect(x: 0, y: 0, width: 1470, height: 926))
+        XCTAssertEqual(frame, screenFrame)
+    }
+
+    func testWallpaperWindowDoesNotInjectSyntheticBackgroundColorIntoMenuBarBackdrop() throws {
+        // Given
+        let source = try String(contentsOfFile: "Sources/WorkshopWallpaperBridgeApp/WallpaperPlayer.swift")
+        let windowStart = try XCTUnwrap(source.range(of: "private final class WallpaperWindow"))
+        let initStart = try XCTUnwrap(source.range(of: "init(asset:", range: windowStart.lowerBound..<source.endIndex))
+        let initEnd = try XCTUnwrap(source.range(of: "func show()", range: initStart.lowerBound..<source.endIndex))
+        let body = String(source[initStart.lowerBound..<initEnd.lowerBound])
+
+        // Then
+        XCTAssertTrue(body.contains("window.isOpaque = false"))
+        XCTAssertTrue(body.contains("window.backgroundColor = .clear"))
+        XCTAssertFalse(body.contains("window.backgroundColor = .black"))
     }
 
     func testAutoPauseDoesNotHideWallpaperWindow() throws {
@@ -243,6 +257,9 @@ final class WallpaperPlayerSuspensionTests: XCTestCase {
     func testSceneWallpaperInitializesTextOnlySceneWithoutPreviewOrTextures() throws {
         // Given
         let root = try Self.makeTempDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
         let packageURL = root.appending(path: "text-only.pkg")
         try Self.writeScenePackage(
             to: packageURL,
@@ -304,6 +321,7 @@ final class WallpaperPlayerSuspensionTests: XCTestCase {
         XCTAssertTrue(source.contains("CATextLayer()"))
         XCTAssertTrue(source.contains("dynamicTextLayers.append"))
         XCTAssertTrue(source.contains("Timer.scheduledTimer"))
+        XCTAssertTrue(source.contains("includeScripted: false"))
         XCTAssertTrue(source.contains("plan.effectSettings"))
         XCTAssertTrue(source.contains("opacityMultiplier(for: layerPlan)"))
         XCTAssertTrue(source.contains("opacityMultiplier(for: plan)"))
@@ -317,7 +335,7 @@ final class WallpaperPlayerSuspensionTests: XCTestCase {
         XCTAssertTrue(source.contains("CIWarpKernel"))
         XCTAssertTrue(source.contains("waterWavesWarp"))
         XCTAssertTrue(source.contains("shaderEffectLayers.append"))
-        XCTAssertTrue(source.contains("startShaderEffectTimerIfNeeded"))
+        XCTAssertTrue(source.contains("startSceneTickSourceIfNeeded"))
         XCTAssertFalse(source.contains(#"CAKeyframeAnimation(keyPath: "transform.translation.y")"#))
         XCTAssertFalse(source.contains(#"CAKeyframeAnimation(keyPath: "transform.translation.x")"#))
         XCTAssertFalse(source.contains(#"layer.add(animation, forKey: "\(keyPrefix)-effect-rotation")"#))
@@ -330,17 +348,36 @@ final class WallpaperPlayerSuspensionTests: XCTestCase {
             SceneLayerEffectSetting(effect: .waterWaves),
             SceneLayerEffectSetting(effect: .waterRipple),
             SceneLayerEffectSetting(effect: .scroll),
+            SceneLayerEffectSetting(effect: .bloom),
+            SceneLayerEffectSetting(effect: .blur),
+            SceneLayerEffectSetting(effect: .chromaticAberration),
+            SceneLayerEffectSetting(effect: .clouds),
+            SceneLayerEffectSetting(effect: .godRays),
+            SceneLayerEffectSetting(effect: .localContrast),
+            SceneLayerEffectSetting(effect: .materialColor),
             SceneLayerEffectSetting(effect: .shake),
             SceneLayerEffectSetting(effect: .spin),
             SceneLayerEffectSetting(effect: .shine),
-            SceneLayerEffectSetting(effect: .opacity)
+            SceneLayerEffectSetting(effect: .opacity),
+            SceneLayerEffectSetting(effect: .pulse)
         ]
 
         // When
         let rendered = SceneWallpaperView.shaderRenderableEffects(from: effects).map(\.effect)
 
         // Then
-        XCTAssertEqual(rendered, [.waterFlow, .waterWaves, .waterRipple, .scroll])
+        XCTAssertEqual(rendered, [
+            .waterFlow,
+            .waterWaves,
+            .waterRipple,
+            .scroll,
+            .bloom,
+            .blur,
+            .chromaticAberration,
+            .godRays,
+            .localContrast,
+            .materialColor
+        ])
     }
 
     func testSceneWallpaperRefreshesSceneScriptTextLayers() throws {
@@ -351,7 +388,34 @@ final class WallpaperPlayerSuspensionTests: XCTestCase {
         XCTAssertTrue(source.contains("SceneScriptTextEvaluator(script:"))
         XCTAssertTrue(source.contains("text.script != nil"))
         XCTAssertTrue(source.contains("SceneScriptRuntime("))
-        XCTAssertTrue(source.contains("1.0 / 24.0"))
+        XCTAssertTrue(source.contains("refreshSceneTickDrivenLayers"))
+        XCTAssertTrue(source.contains("tick.frameTime"))
+        XCTAssertFalse(source.contains("1.0 / 24.0"))
+    }
+
+    func testSceneWallpaperSuspensionPausesAndResumesSceneTickSource() throws {
+        // Given
+        let source = try String(contentsOfFile: "Sources/WorkshopWallpaperBridgeApp/SceneWallpaperView.swift")
+        let start = try XCTUnwrap(source.range(of: "func setPlaybackSuspended"))
+        let end = try XCTUnwrap(source.range(of: "func setDisplayMode", range: start.lowerBound..<source.endIndex))
+        let body = String(source[start.lowerBound..<end.lowerBound])
+
+        // Then
+        XCTAssertTrue(body.contains("sceneTickSource.suspend()"))
+        XCTAssertTrue(body.contains("sceneTickSource.resume()"))
+        XCTAssertTrue(body.contains("startSceneTickSourceIfNeeded()"))
+    }
+
+    func testSceneWallpaperCloseInvalidatesSceneTickSource() throws {
+        // Given
+        let source = try String(contentsOfFile: "Sources/WorkshopWallpaperBridgeApp/SceneWallpaperView.swift")
+        let start = try XCTUnwrap(source.range(of: "func prepareForClose()"))
+        let end = try XCTUnwrap(source.range(of: "private func configureSceneLayer", range: start.lowerBound..<source.endIndex))
+        let body = String(source[start.lowerBound..<end.lowerBound])
+
+        // Then
+        XCTAssertTrue(body.contains("sceneTickSource.invalidate()"))
+        XCTAssertFalse(body.contains("shaderEffectTimer"))
     }
 
     func testSceneWallpaperAnimatesParsedLayerEffects() {
@@ -360,8 +424,10 @@ final class WallpaperPlayerSuspensionTests: XCTestCase {
             SceneLayerEffectSetting(effect: .shake),
             SceneLayerEffectSetting(effect: .spin),
             SceneLayerEffectSetting(effect: .shine),
+            SceneLayerEffectSetting(effect: .pulse),
             SceneLayerEffectSetting(effect: .waterFlow),
             SceneLayerEffectSetting(effect: .waterRipple),
+            SceneLayerEffectSetting(effect: .bloom),
             SceneLayerEffectSetting(effect: .opacity)
         ]
 
@@ -369,16 +435,18 @@ final class WallpaperPlayerSuspensionTests: XCTestCase {
         let animated = effects.map { SceneWallpaperView.isLayerAnimatedEffect($0.effect) }
 
         // Then
-        XCTAssertEqual(animated, [true, true, true, false, false, false])
+        XCTAssertEqual(animated, [true, true, true, true, false, false, false, false])
     }
 
     func testSceneWallpaperSkipsEffectAnimationsThatConflictWithSceneKeyframes() {
         // Then
         XCTAssertFalse(SceneWallpaperView.shouldAnimateLayerEffect(.spin, hasAngleAnimation: true, hasAlphaAnimation: false))
         XCTAssertFalse(SceneWallpaperView.shouldAnimateLayerEffect(.shine, hasAngleAnimation: false, hasAlphaAnimation: true))
+        XCTAssertFalse(SceneWallpaperView.shouldAnimateLayerEffect(.pulse, hasAngleAnimation: false, hasAlphaAnimation: true))
         XCTAssertTrue(SceneWallpaperView.shouldAnimateLayerEffect(.shake, hasAngleAnimation: true, hasAlphaAnimation: true))
         XCTAssertTrue(SceneWallpaperView.shouldAnimateLayerEffect(.spin, hasAngleAnimation: false, hasAlphaAnimation: false))
         XCTAssertTrue(SceneWallpaperView.shouldAnimateLayerEffect(.shine, hasAngleAnimation: false, hasAlphaAnimation: false))
+        XCTAssertTrue(SceneWallpaperView.shouldAnimateLayerEffect(.pulse, hasAngleAnimation: false, hasAlphaAnimation: false))
     }
 
     func testSceneWallpaperDerivesEffectAnimationTimingFromShaderSpeed() {
@@ -431,24 +499,64 @@ final class WallpaperPlayerSuspensionTests: XCTestCase {
         XCTAssertEqual(explicit.y, -0.35, accuracy: 0.000_001)
     }
 
-    func testSceneShaderEffectClockDoesNotAdvanceWhileSuspended() {
+    func testSceneTickClockStopsWhileSuspended() throws {
+        // Given
+        var clock = SceneTickClock()
+
         // When
-        let suspended = SceneWallpaperView.shaderEffectTime(
-            elapsedTime: 4.5,
-            resumeTime: 100,
-            now: 160,
-            isSuspended: true
-        )
-        let running = SceneWallpaperView.shaderEffectTime(
-            elapsedTime: 4.5,
-            resumeTime: 100,
-            now: 103.25,
-            isSuspended: false
-        )
+        let firstTick = clock.advance(by: 0.25)
+        clock.suspend()
+        let suspendedTick = clock.advance(by: 10)
+        clock.resume()
+        let resumedTick = clock.advance(by: 0.5)
 
         // Then
-        XCTAssertEqual(suspended, 4.5, accuracy: 0.000_001)
-        XCTAssertEqual(running, 7.75, accuracy: 0.000_001)
+        XCTAssertEqual(try XCTUnwrap(firstTick).elapsedTime, 0.25, accuracy: 0.000_001)
+        XCTAssertNil(suspendedTick)
+        XCTAssertEqual(try XCTUnwrap(resumedTick).elapsedTime, 0.75, accuracy: 0.000_001)
+        XCTAssertEqual(clock.elapsedTime, 0.75, accuracy: 0.000_001)
+    }
+
+    @MainActor
+    func testSceneTickClockInvalidatesOnClose() throws {
+        // Given
+        let root = try Self.makeTempDirectory()
+        let packageURL = root.appending(path: "text-only.pkg")
+        let tickSource = TestSceneTickSource()
+        try Self.writeScenePackage(
+            to: packageURL,
+            sceneJSON: #"{"objects":[{"text":{"value":"HELLO"},"size":"320 120"}]}"#
+        )
+        let view = try SceneWallpaperView(
+            url: packageURL,
+            previewURL: nil,
+            frame: CGRect(x: 0, y: 0, width: 640, height: 360),
+            displayMode: .fit,
+            sceneTickSource: tickSource
+        )
+
+        // When
+        view.prepareForClose()
+
+        // Then
+        XCTAssertTrue(tickSource.didInvalidate)
+        XCTAssertFalse(tickSource.isRunning)
+    }
+
+    func testSceneShaderEffectClockDoesNotAdvanceWhileSuspended() throws {
+        // When
+        var clock = SceneTickClock()
+        _ = clock.advance(by: 4.5)
+        clock.suspend()
+        let suspendedTick = clock.advance(by: 60)
+        let suspendedTime = clock.elapsedTime
+        clock.resume()
+        let runningTick = clock.advance(by: 3.25)
+
+        // Then
+        XCTAssertNil(suspendedTick)
+        XCTAssertEqual(suspendedTime, 4.5, accuracy: 0.000_001)
+        XCTAssertEqual(try XCTUnwrap(runningTick).elapsedTime, 7.75, accuracy: 0.000_001)
     }
 
     private static func makeTempDirectory() throws -> URL {
@@ -467,6 +575,61 @@ final class WallpaperPlayerSuspensionTests: XCTestCase {
         data.appendInt32(Data(sceneJSON.utf8).count)
         data.append(Data(sceneJSON.utf8))
         try data.write(to: url, options: [.atomic])
+    }
+}
+
+@MainActor
+private final class TestSceneTickSource: SceneTickSource {
+    private var clock = SceneTickClock()
+    private(set) var isRunning = false
+    private(set) var didInvalidate = false
+    var onTick: ((SceneTick) -> Void)?
+
+    var elapsedTime: TimeInterval {
+        clock.elapsedTime
+    }
+
+    var frameTime: TimeInterval {
+        clock.frameTime
+    }
+
+    func start() {
+        guard !didInvalidate else {
+            return
+        }
+        isRunning = true
+    }
+
+    func stop() {
+        isRunning = false
+    }
+
+    func suspend() {
+        clock.suspend()
+        isRunning = false
+    }
+
+    func resume() {
+        clock.resume()
+    }
+
+    func reset() {
+        clock.reset()
+        isRunning = false
+    }
+
+    func invalidate() {
+        clock.invalidate()
+        isRunning = false
+        didInvalidate = true
+        onTick = nil
+    }
+
+    func advance(by delta: TimeInterval) {
+        guard isRunning, let tick = clock.advance(by: delta) else {
+            return
+        }
+        onTick?(tick)
     }
 }
 

--- a/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
+++ b/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
@@ -146,6 +146,14 @@ final class DocumentationTests: XCTestCase {
         XCTAssertTrue(script.contains("BUNDLE_VERSION=\"${BUNDLE_VERSION:-10}\""))
     }
 
+    func testFrameDiffScriptBoundsImageAllocationBeforeDecodingPixels() throws {
+        let script = try String(contentsOfFile: "Scripts/scene-frame-diff.swift")
+
+        XCTAssertTrue(script.contains("maximumImagePixels"))
+        XCTAssertTrue(script.contains("checkedPixelCount"))
+        XCTAssertTrue(script.contains("imageTooLarge"))
+    }
+
     private func assertHeadings(_ headings: [String], appearInOrderIn readme: String) {
         var searchStart = readme.startIndex
         for heading in headings {

--- a/Tests/WorkshopWallpaperCoreTests/ScenePackageTests.swift
+++ b/Tests/WorkshopWallpaperCoreTests/ScenePackageTests.swift
@@ -226,6 +226,82 @@ final class ScenePackageTests: XCTestCase {
         XCTAssertTrue(features.runtimeGaps.contains("audio-analysis-uniforms"))
     }
 
+    func testRuntimeFeatureAnalyzerReportsMaskedEffectComposition() throws {
+        // Given
+        let root = try Fixture.makeTempDirectory()
+        let packageURL = root.appending(path: "masked-composition.pkg")
+        let sceneJSON = """
+        {
+          "objects": [
+            {
+              "id": 1,
+              "name": "Masked layer",
+              "image": "models/fish.json",
+              "effects": [
+                {
+                  "file": "effects/opacity/effect.json",
+                  "passes": [
+                    { "textures": [null, "masks/fish-mask"] }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """
+        try Fixture.writeScenePackage(
+            to: packageURL,
+            sceneJSON: sceneJSON,
+            extraEntries: [
+                (path: "models/fish.json", data: Data(#"{"material":"materials/fish.json"}"#.utf8)),
+                (path: "materials/fish.json", data: Data(#"{"passes":[{"textures":["fish"]}]}"#.utf8)),
+                (path: "materials/fish.tex", data: Data([1])),
+                (path: "masks/fish-mask.tex", data: Data([2]))
+            ]
+        )
+
+        // When
+        let features = try SceneRuntimeFeatureAnalyzer().analyze(url: packageURL)
+
+        // Then
+        XCTAssertTrue(features.requiresMaskedEffectComposition)
+        XCTAssertTrue(features.requiresEngineRenderer)
+        XCTAssertTrue(features.runtimeGaps.contains("masked-effect-composition"))
+    }
+
+    func testRuntimeFeatureAnalyzerIgnoresMaskTextOutsideEffectMaskReferences() throws {
+        // Given
+        let root = try Fixture.makeTempDirectory()
+        let packageURL = root.appending(path: "mask-name-only.pkg")
+        let sceneJSON = """
+        {
+          "objects": [
+            {
+              "id": 1,
+              "name": "Masked layer but no effect mask",
+              "image": "models/fish.json"
+            }
+          ]
+        }
+        """
+        try Fixture.writeScenePackage(
+            to: packageURL,
+            sceneJSON: sceneJSON,
+            extraEntries: [
+                (path: "models/fish.json", data: Data(#"{"material":"materials/fish.json"}"#.utf8)),
+                (path: "materials/fish.json", data: Data(#"{"passes":[{"textures":["fish"]}]}"#.utf8)),
+                (path: "materials/fish.tex", data: Data([1]))
+            ]
+        )
+
+        // When
+        let features = try SceneRuntimeFeatureAnalyzer().analyze(url: packageURL)
+
+        // Then
+        XCTAssertFalse(features.requiresMaskedEffectComposition)
+        XCTAssertFalse(features.runtimeGaps.contains("masked-effect-composition"))
+    }
+
     func testRuntimeFeatureAnalyzerMarksModelOnlySceneAsEngineRendererRequirement() throws {
         // Given
         let root = try Fixture.makeTempDirectory()

--- a/Tests/WorkshopWallpaperCoreTests/SceneRenderPlanTests.swift
+++ b/Tests/WorkshopWallpaperCoreTests/SceneRenderPlanTests.swift
@@ -354,6 +354,20 @@ final class SceneRenderPlanTests: XCTestCase {
                     { "constantshadervalues": { "speed": 0.45, "strength": 0.47, "direction": "0.2 1 0" } }
                   ],
                   "visible": true
+                },
+                {
+                  "file": "effects/bloom/effect.json",
+                  "passes": [
+                    { "constantshadervalues": { "strength": 0.18, "scale": 24 } }
+                  ],
+                  "visible": true
+                },
+                {
+                  "file": "effects/chromaticaberration/effect.json",
+                  "passes": [
+                    { "constantshadervalues": { "strength": 0.03, "animationspeed": 0.5 } }
+                  ],
+                  "visible": true
                 }
               ]
             },
@@ -417,10 +431,13 @@ final class SceneRenderPlanTests: XCTestCase {
         XCTAssertEqual(plan.layers.count, 3)
         let foam = try XCTUnwrap(plan.layers.first { $0.name == "Espuma" })
         XCTAssertTrue(foam.effects.contains(.waterFlow))
+        XCTAssertTrue(foam.effects.contains(.bloom))
+        XCTAssertTrue(foam.effects.contains(.chromaticAberration))
         XCTAssertEqual(foam.effectSettings.first?.effect, .waterFlow)
         XCTAssertEqual(foam.effectSettings.first?.speed, 0.45)
         XCTAssertEqual(foam.effectSettings.first?.strength, 0.47)
         XCTAssertEqual(foam.effectSettings.first?.direction, SceneVector3(x: 0.2, y: 1, z: 0))
+        XCTAssertEqual(foam.effectSettings.map(\.effect), [.waterFlow, .bloom, .chromaticAberration])
         let compose = try XCTUnwrap(plan.layers.first { $0.name == "Compose" })
         XCTAssertTrue(compose.isEffectOnly)
         XCTAssertTrue(compose.effects.contains(.waterRipple))
@@ -555,6 +572,96 @@ final class SceneRenderPlanTests: XCTestCase {
         XCTAssertEqual(plan.layers.map(\.name), ["Title shadow", "Title fill"])
         XCTAssertEqual(plan.layers.filter { $0.text != nil }.count, 2)
         XCTAssertFalse(plan.layers[0].effectSettings.first?.usesMask ?? true)
+    }
+
+    func testRenderPlanPreservesMaskReferencesForEffectSettings() throws {
+        // Given
+        let root = try Fixture.makeTempDirectory()
+        let packageURL = root.appending(path: "masked-effect.pkg")
+        let sceneJSON = """
+        {
+          "objects": [
+            {
+              "id": 1,
+              "name": "Masked fish",
+              "image": "models/fish.json",
+              "effects": [
+                {
+                  "file": "effects/opacity/effect.json",
+                  "passes": [
+                    {
+                      "constantshadervalues": { "alpha": 0.75 },
+                      "textures": [null, "masks/fish-mask"]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """
+        try Fixture.writeScenePackage(
+            to: packageURL,
+            sceneJSON: sceneJSON,
+            extraEntries: [
+                (path: "models/fish.json", data: Data(#"{"material":"materials/fish.json"}"#.utf8)),
+                (path: "materials/fish.json", data: Data(#"{"passes":[{"textures":["fish"]}]}"#.utf8)),
+                (path: "materials/fish.tex", data: Fixture.texData(width: 1, height: 1, imageData: png)),
+                (path: "masks/fish-mask.tex", data: Fixture.texData(width: 1, height: 1, imageData: png))
+            ]
+        )
+
+        // When
+        let plan = try SceneRenderPlanBuilder().build(url: packageURL)
+
+        // Then
+        let setting = try XCTUnwrap(plan.layers.first?.effectSettings.first)
+        XCTAssertEqual(setting.effect, .opacity)
+        XCTAssertTrue(setting.usesMask)
+        XCTAssertEqual(setting.maskReference?.source, "masks/fish-mask")
+        XCTAssertEqual(setting.maskReference?.texturePath, "masks/fish-mask.tex")
+    }
+
+    func testRenderPlanResolvesOpacityMaskTexture() throws {
+        // Given
+        let root = try Fixture.makeTempDirectory()
+        let packageURL = root.appending(path: "opacity-mask-texture.pkg")
+        let sceneJSON = """
+        {
+          "objects": [
+            {
+              "id": 1,
+              "name": "Masked fish",
+              "image": "models/fish.json",
+              "effects": [
+                {
+                  "file": "effects/opacity/effect.json",
+                  "passes": [
+                    { "textures": [null, "masks/fish-mask"] }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """
+        try Fixture.writeScenePackage(
+            to: packageURL,
+            sceneJSON: sceneJSON,
+            extraEntries: [
+                (path: "models/fish.json", data: Data(#"{"material":"materials/fish.json"}"#.utf8)),
+                (path: "materials/fish.json", data: Data(#"{"passes":[{"textures":["fish"]}]}"#.utf8)),
+                (path: "materials/fish.tex", data: Fixture.texData(width: 1, height: 1, imageData: png)),
+                (path: "masks/fish-mask.tex", data: Fixture.texData(width: 1, height: 1, imageData: png))
+            ]
+        )
+
+        // When
+        let plan = try SceneRenderPlanBuilder().build(url: packageURL)
+
+        // Then
+        XCTAssertNotNil(plan.textures["materials/fish.tex"])
+        XCTAssertNotNil(plan.textures["masks/fish-mask.tex"])
     }
 
     func testRenderPlanPreservesScrollAxisSpeedsForEffectMotionFallbacks() throws {


### PR DESCRIPTION
## Summary
- Replace the fixed scene timer with a display-linked native scene tick source so scripted/effect layers advance like live wallpaper content.
- Add native scene effect/mask metadata parsing plus opacity-mask composition for decoded mask textures; keep unsupported cloud pixels diagnostic-only until they are truly rendered.
- Extend wallpaper windows behind the menu bar and Dock with a clear non-opaque backing, so the menu bar samples the continuous moving wallpaper while preserving the user configured macOS menu bar color/style.
- Add bounded frame-diff tooling and regression coverage for menu-bar continuity, mask handling, unsupported feature diagnostics, and bitmap allocation guards.

Fixes #1

## Verification
- `swift test` — 190 tests, 0 failures.
- `bash Scripts/package-app.sh` — packaged app and DMG generated at `dist/WorkshopWallpaperBridge-macOS-arm64.dmg`.
- `swift run wwbctl doctor` — library, ffmpeg, and platform checks passed.
- `git diff --cached --check` — passed before commit.
- `Scripts/scene-frame-diff.swift` direct fixture/diff smoke — changedRatio 1.0 on controlled fixture.
- Manual GUI/window capture QA on the packaged app: full wallpaper window changedRatio 0.810268, top menu-bar strip changedRatio 0.946220, blackRatio 0.

## Notes
- The Windows reference video remains comparison evidence only; this does not add video playback as a runtime fallback.
- This native-first path supersedes the earlier rendered-cache direction for scenes that can be advanced directly.
- Remaining full Wallpaper Engine runtime gaps stay surfaced through diagnostics instead of being hidden.

AI assistance: Codex implemented and verified this change.