### PR TITLE
ci: allow release without signing secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Run tests
         run: swift test
 
-      - name: Validate release signing secrets
+      - name: Resolve release signing mode
+        id: signing
         env:
           MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64 }}
           MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD }}
@@ -62,7 +63,15 @@ jobs:
           MACOS_NOTARY_PASSWORD: ${{ secrets.MACOS_NOTARY_PASSWORD }}
         run: |
           set -euo pipefail
-          missing=0
+          required=(
+            MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64
+            MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD
+            MACOS_NOTARY_APPLE_ID
+            MACOS_NOTARY_TEAM_ID
+            MACOS_NOTARY_PASSWORD
+          )
+          present=0
+          missing=()
           for name in \
             MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64 \
             MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD \
@@ -71,13 +80,35 @@ jobs:
             MACOS_NOTARY_PASSWORD
           do
             if [ -z "${!name:-}" ]; then
-              echo "::error::$name is required for a signed and notarized public release."
-              missing=1
+              missing+=("$name")
+            else
+              present=$((present + 1))
             fi
           done
-          exit "$missing"
+
+          if [ "$present" -eq 0 ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Release signing secrets are absent; publishing an unsigned DMG. Configure ${required[*]} for signed and notarized releases."
+            {
+              echo "### Release signing"
+              echo
+              echo "Signing secrets are absent, so this run will publish an unsigned DMG."
+              echo "Configure all required macOS signing and notarization secrets to publish a Developer ID signed and notarized DMG."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            for name in "${missing[@]}"; do
+              echo "::error::$name is required when any release signing secret is configured."
+            done
+            exit 1
+          fi
+
+          echo "available=true" >> "$GITHUB_OUTPUT"
 
       - name: Import Developer ID certificate
+        if: steps.signing.outputs.available == 'true'
         env:
           MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64 }}
           MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD }}
@@ -122,10 +153,10 @@ jobs:
         env:
           APP_VERSION: ${{ steps.version.outputs.version }}
           BUNDLE_VERSION: ${{ github.run_number }}
-          SIGN_IDENTITY: Developer ID Application
-          NOTARY_PROFILE: workshop-wallpaper-bridge-notary
-          REQUIRE_SIGNING: "1"
-          REQUIRE_NOTARIZATION: "1"
+          SIGN_IDENTITY: ${{ steps.signing.outputs.available == 'true' && 'Developer ID Application' || '' }}
+          NOTARY_PROFILE: ${{ steps.signing.outputs.available == 'true' && 'workshop-wallpaper-bridge-notary' || '' }}
+          REQUIRE_SIGNING: ${{ steps.signing.outputs.available == 'true' && '1' || '0' }}
+          REQUIRE_NOTARIZATION: ${{ steps.signing.outputs.available == 'true' && '1' || '0' }}
         run: bash Scripts/package-app.sh
 
       - name: Create checksum

--- a/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
+++ b/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
@@ -115,19 +115,24 @@ final class DocumentationTests: XCTestCase {
         XCTAssertTrue(workflow.contains("contents: write"))
     }
 
-    func testReleaseWorkflowRequiresSignedNotarizedGatekeeperCheckedDmg() throws {
+    func testReleaseWorkflowSupportsSigningWhenSecretsExistAndUnsignedFallbackOtherwise() throws {
         let workflow = try String(contentsOfFile: ".github/workflows/release.yml")
 
+        XCTAssertTrue(workflow.contains("Resolve release signing mode"))
+        XCTAssertTrue(workflow.contains("available=false"))
+        XCTAssertTrue(workflow.contains("Release signing secrets are absent; publishing an unsigned DMG"))
         XCTAssertTrue(workflow.contains("MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_BASE64"))
         XCTAssertTrue(workflow.contains("MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD"))
         XCTAssertTrue(workflow.contains("MACOS_NOTARY_APPLE_ID"))
         XCTAssertTrue(workflow.contains("MACOS_NOTARY_TEAM_ID"))
         XCTAssertTrue(workflow.contains("MACOS_NOTARY_PASSWORD"))
+        XCTAssertTrue(workflow.contains("is required when any release signing secret is configured"))
         XCTAssertTrue(workflow.contains("xcrun notarytool store-credentials"))
-        XCTAssertTrue(workflow.contains("SIGN_IDENTITY: Developer ID Application"))
-        XCTAssertTrue(workflow.contains("NOTARY_PROFILE: workshop-wallpaper-bridge-notary"))
-        XCTAssertTrue(workflow.contains("REQUIRE_SIGNING: \"1\""))
-        XCTAssertTrue(workflow.contains("REQUIRE_NOTARIZATION: \"1\""))
+        XCTAssertTrue(workflow.contains("if: steps.signing.outputs.available == 'true'"))
+        XCTAssertTrue(workflow.contains("SIGN_IDENTITY: ${{ steps.signing.outputs.available == 'true' && 'Developer ID Application' || '' }}"))
+        XCTAssertTrue(workflow.contains("NOTARY_PROFILE: ${{ steps.signing.outputs.available == 'true' && 'workshop-wallpaper-bridge-notary' || '' }}"))
+        XCTAssertTrue(workflow.contains("REQUIRE_SIGNING: ${{ steps.signing.outputs.available == 'true' && '1' || '0' }}"))
+        XCTAssertTrue(workflow.contains("REQUIRE_NOTARIZATION: ${{ steps.signing.outputs.available == 'true' && '1' || '0' }}"))
     }
 
     func testPackagingScriptVerifiesNotarizedQuarantinedApp() throws {


### PR DESCRIPTION
## Summary
- Restore release publishing when no macOS signing secrets are configured, matching the repository current configuration and previous release behavior.
- Keep the signed/notarized path active when all required signing secrets are present.
- Fail on partial signing configuration so a half-configured secret set does not silently publish unsigned output.

## Verification
- `ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/release.yml\")"`
- `swift test` — 190 tests, 0 failures.
- `bash Scripts/package-app.sh` — DMG generated locally.
- `swift run wwbctl doctor` — passed.
- `git diff --cached --check` — passed before commit.

## Release recovery plan
After merge, dispatch the updated Release workflow from `main` with `tag=v1.1.4`. The workflow definition will come from `main`, while the checkout still uses the existing `v1.1.4` tag.

AI assistance: Codex implemented and verified this workflow fix.