### PR TITLE
feat: add Pro license gating

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -30,6 +30,18 @@ Workshop Wallpaper Bridge가 도움이 되었다면 [Patreon](https://www.patreo
 
 **Auto-check Updates**가 켜져 있으면 앱이 GitHub Releases에서 업데이트를 자동 확인합니다. 설정 창의 **Check Updates** 또는 메뉴바 메뉴의 **Check for Updates**로 수동 확인할 수 있습니다. 새 릴리즈가 있으면 **Download Update**가 최신 DMG를 다운로드합니다.
 
+## 무료와 Pro
+
+무료 앱은 로컬 import, scan, desktop playback, display mode, 수동 update check, video conversion을 계속 제공합니다.
+
+Pro는 signed release 유지보수가 필요한 운영체제 통합 기능을 해제합니다.
+
+- 자동 update check.
+- **Set Still Wallpaper**로 desktop과 Lock Screen 정적 배경화면 쓰기.
+- **Animate Screen Saver**와 **Screen Saver Settings**로 animated screen saver 제어.
+
+설정 창에 Pro license key를 입력하면 현재 Mac에서 Pro가 해제됩니다. 프로젝트 경계는 그대로 유지됩니다. Pro는 Steam 다운로드, 계정 접근, DRM 우회, cloud sync, 제작자 asset 재배포를 추가하지 않습니다.
+
 ## 사용 방법
 
 Wallpaper Engine 프로젝트를 쓰는 경우:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ Public releases are Developer ID signed, notarized, and Gatekeeper-checked with 
 
 The app checks GitHub Releases for updates automatically when **Auto-check Updates** is enabled. Use **Check Updates** from the settings window, or **Check for Updates** from the menu bar menu, to check manually. When a newer release exists, **Download Update** downloads the latest DMG.
 
+## Free And Pro
+
+The free app keeps local import, scanning, desktop playback, display modes, manual update checks, and video conversion available.
+
+Pro unlocks the operating-system integration features that need ongoing signed-release maintenance:
+
+- Automatic update checks.
+- Writing a still desktop and Lock Screen wallpaper with **Set Still Wallpaper**.
+- Animated screen saver controls with **Animate Screen Saver** and **Screen Saver Settings**.
+
+Enter a Pro license key in the settings window to unlock Pro on the current Mac. The project stays local-only: Pro does not add Steam downloads, account access, DRM bypassing, cloud sync, or creator asset redistribution.
+
 ## Use It
 
 For Wallpaper Engine projects:

--- a/Sources/WorkshopWallpaperBridgeApp/AppViewModel.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/AppViewModel.swift
@@ -18,6 +18,8 @@ final class AppViewModel: ObservableObject {
     @Published private(set) var selectedLibraryAssetIds: Set<WallpaperAsset.ID> = []
     @Published var status = "Choose a copied Wallpaper Engine Workshop folder to begin."
     @Published var isWorking = false
+    @Published var proLicenseKey = ""
+    @Published private(set) var isProUnlocked = false
     @Published var displayMode: WallpaperDisplayMode = .fit {
         didSet {
             WallpaperPlayer.shared.setDisplayMode(displayMode)
@@ -38,12 +40,24 @@ final class AppViewModel: ObservableObject {
             guard !isSyncingLockScreenAnimation, lockScreenAnimationEnabled != oldValue else {
                 return
             }
+            guard isProUnlocked || !lockScreenAnimationEnabled else {
+                isSyncingLockScreenAnimation = true
+                lockScreenAnimationEnabled = false
+                isSyncingLockScreenAnimation = false
+                status = "Unlock Pro to animate the screen saver."
+                return
+            }
             setLockScreenAnimation(lockScreenAnimationEnabled)
         }
     }
     @Published var automaticallyCheckForUpdates = true {
         didSet {
             guard automaticallyCheckForUpdates != oldValue else {
+                return
+            }
+            guard isProUnlocked || !automaticallyCheckForUpdates else {
+                automaticallyCheckForUpdates = false
+                status = "Unlock Pro to enable automatic update checks."
                 return
             }
             userDefaults.set(automaticallyCheckForUpdates, forKey: PreferenceKey.automaticallyCheckForUpdates)
@@ -165,6 +179,12 @@ final class AppViewModel: ObservableObject {
         libraryAssets.filter { selectedLibraryAssetIds.contains($0.id) }
     }
 
+    var proStatusText: String {
+        isProUnlocked
+            ? "Pro unlocked. Thanks for supporting compatibility work."
+            : "Free includes local import and desktop playback. Pro unlocks automatic updates, still wallpaper writing, and animated screen saver controls."
+    }
+
     func selectLibraryAssets(_ ids: Set<WallpaperAsset.ID>) {
         selectedLibraryAssetIds = ids
         normalizeLibrarySelection(allowEmpty: true)
@@ -173,6 +193,29 @@ final class AppViewModel: ObservableObject {
     func selectScannedAssets(_ ids: Set<WallpaperAsset.ID>) {
         selectedScannedAssetIds = ids
         normalizeScannedSelection(allowEmpty: true)
+    }
+
+    func activateProLicense() {
+        let normalized = ProLicenseValidator.normalize(proLicenseKey)
+        guard ProLicenseValidator.isValid(normalized) else {
+            isProUnlocked = false
+            userDefaults.removeObject(forKey: PreferenceKey.proLicenseKey)
+            status = "That Pro license key is invalid."
+            return
+        }
+        proLicenseKey = normalized
+        isProUnlocked = true
+        userDefaults.set(normalized, forKey: PreferenceKey.proLicenseKey)
+        status = "Pro unlocked."
+    }
+
+    func clearProLicense() {
+        proLicenseKey = ""
+        isProUnlocked = false
+        userDefaults.removeObject(forKey: PreferenceKey.proLicenseKey)
+        automaticallyCheckForUpdates = false
+        lockScreenAnimationEnabled = false
+        status = "Pro license removed."
     }
 }
 
@@ -269,6 +312,10 @@ extension AppViewModel {
     }
 
     func setStillWallpaper() {
+        guard isProUnlocked else {
+            status = "Unlock Pro to set the macOS desktop and Lock Screen still wallpaper."
+            return
+        }
         guard let asset = selectedLibraryAsset else {
             status = "Select a library project first."
             return
@@ -349,6 +396,10 @@ extension AppViewModel {
     }
 
     func openScreenSaverSettings() {
+        guard isProUnlocked else {
+            status = "Unlock Pro to use animated screen saver controls."
+            return
+        }
         do {
             try lockScreenAnimationController.openScreenSaverSettings()
             status = "Installed and selected Workshop Wallpaper Bridge Screen Saver."
@@ -391,7 +442,7 @@ extension AppViewModel {
     }
 
     func performAutomaticUpdateCheckIfNeeded(force: Bool = false, now: Date = Date()) async {
-        guard automaticallyCheckForUpdates else {
+        guard automaticallyCheckForUpdates, isProUnlocked else {
             return
         }
         if !force,
@@ -477,6 +528,11 @@ extension AppViewModel {
     }
 
     private func restorePreferences() {
+        if let storedLicense = userDefaults.string(forKey: PreferenceKey.proLicenseKey),
+           ProLicenseValidator.isValid(storedLicense) {
+            proLicenseKey = ProLicenseValidator.normalize(storedLicense)
+            isProUnlocked = true
+        }
         if let rawDisplayMode = userDefaults.string(forKey: PreferenceKey.displayMode),
            let storedDisplayMode = WallpaperDisplayMode(rawValue: rawDisplayMode) {
             displayMode = storedDisplayMode
@@ -484,13 +540,15 @@ extension AppViewModel {
         if userDefaults.object(forKey: PreferenceKey.autoPauseWhenCovered) != nil {
             autoPauseWhenCovered = userDefaults.bool(forKey: PreferenceKey.autoPauseWhenCovered)
         }
-        if userDefaults.object(forKey: PreferenceKey.lockScreenAnimationEnabled) != nil {
+        if isProUnlocked, userDefaults.object(forKey: PreferenceKey.lockScreenAnimationEnabled) != nil {
             isSyncingLockScreenAnimation = true
             lockScreenAnimationEnabled = userDefaults.bool(forKey: PreferenceKey.lockScreenAnimationEnabled)
             isSyncingLockScreenAnimation = false
         }
-        if userDefaults.object(forKey: PreferenceKey.automaticallyCheckForUpdates) != nil {
+        if isProUnlocked, userDefaults.object(forKey: PreferenceKey.automaticallyCheckForUpdates) != nil {
             automaticallyCheckForUpdates = userDefaults.bool(forKey: PreferenceKey.automaticallyCheckForUpdates)
+        } else if !isProUnlocked {
+            automaticallyCheckForUpdates = false
         }
     }
 
@@ -623,4 +681,5 @@ private enum PreferenceKey {
     static let lastPlayedAssetId = "lastPlayedAssetId"
     static let automaticallyCheckForUpdates = "automaticallyCheckForUpdates"
     static let lastUpdateCheckAt = "lastUpdateCheckAt"
+    static let proLicenseKey = "proLicenseKey"
 }

--- a/Sources/WorkshopWallpaperBridgeApp/ContentView.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/ContentView.swift
@@ -42,8 +42,11 @@ struct ContentView: View {
                 headerToggle("Open at Login", isOn: $model.launchAtLogin)
                 headerToggle("Auto-pause behind apps", isOn: $model.autoPauseWhenCovered)
                 headerToggle("Animate Screen Saver", isOn: $model.lockScreenAnimationEnabled)
+                    .disabled(!model.isProUnlocked)
                 headerToggle("Auto-check Updates", isOn: $model.automaticallyCheckForUpdates)
+                    .disabled(!model.isProUnlocked)
             }
+            proPanel
 
             HStack(spacing: 8) {
                 Button("Check Updates") {
@@ -59,6 +62,33 @@ struct ContentView: View {
             }
         }
         .padding()
+    }
+
+    private var proPanel: some View {
+        HStack(spacing: 8) {
+            Text(model.isProUnlocked ? "Pro" : "Free")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(model.isProUnlocked ? .green : .secondary)
+                .frame(width: 38, alignment: .leading)
+            Text(model.proStatusText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Spacer()
+            if model.isProUnlocked {
+                Button("Remove Pro") {
+                    model.clearProLicense()
+                }
+            } else {
+                TextField("WWB-PRO-XXXX-XXXX-CHECK", text: $model.proLicenseKey)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 230)
+                Button("Unlock Pro") {
+                    model.activateProLicense()
+                }
+                .disabled(model.proLicenseKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
     }
 
     private func headerToggle(_ title: String, isOn: Binding<Bool>) -> some View {
@@ -172,13 +202,14 @@ struct ContentView: View {
                 actionButton("Set Still Wallpaper") {
                     model.setStillWallpaper()
                 }
-                .disabled(model.selectedLibraryAsset == nil)
+                .disabled(model.selectedLibraryAsset == nil || !model.isProUnlocked)
                 Spacer()
             }
             HStack(spacing: 8) {
                 actionButton("Screen Saver Settings") {
                     model.openScreenSaverSettings()
                 }
+                .disabled(!model.isProUnlocked)
                 actionButton(model.selectedLibraryAssetCount > 1 ? "Remove Selected" : "Remove") {
                     model.removeSelectedLibraryAssets()
                 }

--- a/Sources/WorkshopWallpaperBridgeApp/ProLicense.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/ProLicense.swift
@@ -1,0 +1,38 @@
+import CryptoKit
+import Foundation
+
+enum ProLicenseValidator {
+    static func normalize(_ key: String) -> String {
+        key
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .uppercased()
+            .replacingOccurrences(of: " ", with: "-")
+            .replacingOccurrences(of: "_", with: "-")
+    }
+
+    static func isValid(_ key: String) -> Bool {
+        let normalized = normalize(key)
+        let parts = normalized.split(separator: "-", omittingEmptySubsequences: false)
+        guard parts.count == 5,
+              parts[0] == "WWB",
+              parts[1] == "PRO",
+              parts[2].count == 4,
+              parts[3].count == 4,
+              parts[4].count == 4,
+              parts.dropFirst(2).allSatisfy(isAlphaNumeric) else {
+            return false
+        }
+        return parts[4] == checksum(for: parts.prefix(4).joined(separator: "-"))
+    }
+
+    private static func checksum(for payload: String) -> String {
+        let digest = SHA256.hash(data: Data("\(payload)-3XHAUST".utf8))
+        return digest.prefix(2).map { String(format: "%02X", $0) }.joined()
+    }
+
+    private static func isAlphaNumeric(_ part: Substring) -> Bool {
+        part.allSatisfy { character in
+            character.isASCII && (character.isNumber || character.isLetter)
+        }
+    }
+}

--- a/Sources/WorkshopWallpaperBridgeApp/StatusMenu.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/StatusMenu.swift
@@ -12,7 +12,12 @@ struct StatusMenu: View {
         Toggle("Open at Login", isOn: $model.launchAtLogin)
         Toggle("Auto-pause Behind Apps", isOn: $model.autoPauseWhenCovered)
         Toggle("Animate Screen Saver", isOn: $model.lockScreenAnimationEnabled)
+            .disabled(!model.isProUnlocked)
         Toggle("Auto-check Updates", isOn: $model.automaticallyCheckForUpdates)
+            .disabled(!model.isProUnlocked)
+        Button(model.isProUnlocked ? "Pro Unlocked" : "Unlock Pro...") {
+            SettingsWindowCoordinator.shared.show(model: model)
+        }
         Button("Check for Updates") {
             model.checkForUpdates()
         }
@@ -28,6 +33,7 @@ struct StatusMenu: View {
         Button("Open Screen Saver Settings") {
             model.openScreenSaverSettings()
         }
+        .disabled(!model.isProUnlocked)
         Button("Stop Playback") {
             model.stopPlayback()
         }

--- a/Tests/WorkshopWallpaperBridgeAppTests/AppViewModelTests.swift
+++ b/Tests/WorkshopWallpaperBridgeAppTests/AppViewModelTests.swift
@@ -5,6 +5,8 @@ import WorkshopWallpaperCore
 
 @MainActor
 final class AppViewModelTests: XCTestCase {
+    private let validProLicenseKey = "WWB-PRO-TEST-2026-ABDC"
+
     func testImportSelectedImportsMultipleScannedAssets() throws {
         // Given
         let sourceRoot = try makeTempDirectory()
@@ -205,6 +207,7 @@ final class AppViewModelTests: XCTestCase {
     func testInitRestoresLockScreenAnimationPreferenceWithoutInstalling() throws {
         // Given
         let defaults = try makeUserDefaults()
+        defaults.set(validProLicenseKey, forKey: "proLicenseKey")
         defaults.set(true, forKey: "lockScreenAnimationEnabled")
         let lockScreen = MockLockScreenAnimationController()
 
@@ -231,6 +234,7 @@ final class AppViewModelTests: XCTestCase {
             lockScreenAnimationController: lockScreen,
             userDefaults: defaults
         )
+        unlockPro(model)
 
         // When
         model.lockScreenAnimationEnabled = true
@@ -339,6 +343,7 @@ final class AppViewModelTests: XCTestCase {
     func testAutomaticUpdateCheckHonorsPreferenceAndInterval() async throws {
         // Given
         let defaults = try makeUserDefaults()
+        defaults.set(validProLicenseKey, forKey: "proLicenseKey")
         let now = Date(timeIntervalSince1970: 100)
         defaults.set(now, forKey: "lastUpdateCheckAt")
         let checker = MockUpdateChecker(
@@ -380,6 +385,96 @@ final class AppViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(checker.requestedVersions.isEmpty)
+    }
+
+    func testProLicenseUnlocksAndPersists() throws {
+        // Given
+        let defaults = try makeUserDefaults()
+        let model = AppViewModel(
+            store: LibraryStore(root: try makeTempDirectory()),
+            loginItemController: MockLoginItemController(),
+            userDefaults: defaults
+        )
+        model.proLicenseKey = " wwb pro test 2026 abdc "
+
+        // When
+        model.activateProLicense()
+
+        // Then
+        XCTAssertTrue(model.isProUnlocked)
+        XCTAssertEqual(model.proLicenseKey, validProLicenseKey)
+        XCTAssertEqual(defaults.string(forKey: "proLicenseKey"), validProLicenseKey)
+        XCTAssertEqual(model.status, "Pro unlocked.")
+    }
+
+    func testInvalidProLicenseIsRejected() throws {
+        // Given
+        let defaults = try makeUserDefaults()
+        let model = AppViewModel(
+            store: LibraryStore(root: try makeTempDirectory()),
+            loginItemController: MockLoginItemController(),
+            userDefaults: defaults
+        )
+        model.proLicenseKey = "WWB-PRO-TEST-2026-0000"
+
+        // When
+        model.activateProLicense()
+
+        // Then
+        XCTAssertFalse(model.isProUnlocked)
+        XCTAssertNil(defaults.string(forKey: "proLicenseKey"))
+        XCTAssertEqual(model.status, "That Pro license key is invalid.")
+    }
+
+    func testFreePlanBlocksProScreenSaverAndAutomaticUpdates() async throws {
+        // Given
+        let checker = MockUpdateChecker(
+            result: .upToDate(currentVersion: "1.1.0", latestVersion: "1.1.0")
+        )
+        let lockScreen = MockLockScreenAnimationController()
+        let model = AppViewModel(
+            store: LibraryStore(root: try makeTempDirectory()),
+            loginItemController: MockLoginItemController(),
+            lockScreenAnimationController: lockScreen,
+            updateChecker: checker,
+            userDefaults: try makeUserDefaults()
+        )
+
+        // When
+        model.lockScreenAnimationEnabled = true
+        model.automaticallyCheckForUpdates = true
+        await model.performAutomaticUpdateCheckIfNeeded(force: true)
+
+        // Then
+        XCTAssertFalse(model.lockScreenAnimationEnabled)
+        XCTAssertFalse(model.automaticallyCheckForUpdates)
+        XCTAssertTrue(lockScreen.enabledRequests.isEmpty)
+        XCTAssertTrue(checker.requestedVersions.isEmpty)
+        XCTAssertEqual(model.status, "Unlock Pro to enable automatic update checks.")
+    }
+
+    func testFreePlanBlocksStillWallpaperAndScreenSaverSettings() throws {
+        // Given
+        let lockScreen = MockLockScreenAnimationController()
+        let model = AppViewModel(
+            store: LibraryStore(root: try makeTempDirectory()),
+            loginItemController: MockLoginItemController(),
+            lockScreenAnimationController: lockScreen,
+            userDefaults: try makeUserDefaults()
+        )
+
+        // When
+        model.setStillWallpaper()
+        let stillWallpaperStatus = model.status
+        model.openScreenSaverSettings()
+
+        // Then
+        XCTAssertEqual(
+            stillWallpaperStatus,
+            "Unlock Pro to set the macOS desktop and Lock Screen still wallpaper."
+        )
+        XCTAssertEqual(model.status, "Unlock Pro to use animated screen saver controls.")
+        XCTAssertFalse(lockScreen.didOpenSettings)
     }
 
     func testStopPlaybackClearsLastPlayedWallpaperPreference() throws {
@@ -435,6 +530,11 @@ final class AppViewModelTests: XCTestCase {
             redistributionAllowed: false,
             issues: []
         )
+    }
+
+    private func unlockPro(_ model: AppViewModel) {
+        model.proLicenseKey = validProLicenseKey
+        model.activateProLicense()
     }
 }
 

--- a/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
+++ b/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
@@ -6,6 +6,7 @@ final class DocumentationTests: XCTestCase {
         let expectedHeadings = [
             "## Demo",
             "## Download",
+            "## Free And Pro",
             "## Use It",
             "## What Works",
             "## Screen Saver",
@@ -39,6 +40,7 @@ final class DocumentationTests: XCTestCase {
         let expectedHeadings = [
             "## 데모",
             "## 다운로드",
+            "## 무료와 Pro",
             "## 사용 방법",
             "## 지원 범위",
             "## 화면 보호기",
@@ -76,6 +78,7 @@ final class DocumentationTests: XCTestCase {
             XCTAssertTrue(readme.contains("MP4"))
             XCTAssertTrue(readme.contains("scene.pkg"))
             XCTAssertTrue(readme.contains("ffmpeg"))
+            XCTAssertTrue(readme.contains("Pro"))
             XCTAssertTrue(readme.contains("Steam Workshop"))
             XCTAssertTrue(readme.contains("DRM"))
             XCTAssertTrue(readme.contains("~/Library/Application Support/WorkshopWallpaperBridge"))


### PR DESCRIPTION
## Summary
- add a local Pro license unlock flow in the settings UI
- keep local import, desktop playback, manual update checks, and video conversion free
- gate automatic update checks, still wallpaper writing, and animated screen saver controls behind Pro
- document the Free/Pro split in English and Korean README files

## Tests
- `swift test --filter AppViewModelTests`
- `swift test --filter DocumentationTests`
- `swift test`
- `bash Scripts/package-app.sh`
- `swift run wwbctl doctor`
- `git diff --cached --check`

## Manual QA
- Opened the packaged app from this branch.
- Verified Free state disables Pro-only controls.
- Entered `WWB-PRO-TEST-2026-ABDC`, unlocked Pro, and verified Pro-only controls enabled.
- Removed the test license afterward.

AI assistance: Codex implemented and verified this change.