### PR TITLE
ci: support legacy release archive uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,26 +160,38 @@ jobs:
         run: bash Scripts/package-app.sh
 
       - name: Create checksum
+        id: artifact
         run: |
           set -euo pipefail
-          cd dist
-          shasum -a 256 WorkshopWallpaperBridge-macOS-arm64.dmg > WorkshopWallpaperBridge-macOS-arm64.dmg.sha256
+          artifact_count="$(find dist -maxdepth 1 -type f \( -name "*.dmg" -o -name "*.zip" \) | wc -l | tr -d ' ')"
+          if [ "$artifact_count" -ne 1 ]; then
+            echo "::error::Expected exactly one release archive in dist, found $artifact_count."
+            find dist -maxdepth 1 -type f -print
+            exit 1
+          fi
+          artifact="$(find dist -maxdepth 1 -type f \( -name "*.dmg" -o -name "*.zip" \) | sort | head -n 1)"
+          checksum="$artifact.sha256"
+          shasum -a 256 "$artifact" > "$checksum"
+          echo "path=$artifact" >> "$GITHUB_OUTPUT"
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
       - name: Publish release assets
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ steps.version.outputs.tag }}
+          RELEASE_ARTIFACT: ${{ steps.artifact.outputs.path }}
+          RELEASE_CHECKSUM: ${{ steps.artifact.outputs.checksum }}
         run: |
           set -euo pipefail
           if gh release view "$TAG_NAME" >/dev/null 2>&1; then
             gh release upload "$TAG_NAME" \
-              dist/WorkshopWallpaperBridge-macOS-arm64.dmg \
-              dist/WorkshopWallpaperBridge-macOS-arm64.dmg.sha256 \
+              "$RELEASE_ARTIFACT" \
+              "$RELEASE_CHECKSUM" \
               --clobber
           else
             gh release create "$TAG_NAME" \
-              dist/WorkshopWallpaperBridge-macOS-arm64.dmg \
-              dist/WorkshopWallpaperBridge-macOS-arm64.dmg.sha256 \
+              "$RELEASE_ARTIFACT" \
+              "$RELEASE_CHECKSUM" \
               --title "$TAG_NAME" \
               --generate-notes \
               --verify-tag

--- a/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
+++ b/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
@@ -105,13 +105,16 @@ final class DocumentationTests: XCTestCase {
         XCTAssertTrue(workflow.contains("macos-15"))
     }
 
-    func testReleaseWorkflowPublishesDmgAndChecksum() throws {
+    func testReleaseWorkflowPublishesReleaseArchiveAndChecksum() throws {
         let workflow = try String(contentsOfFile: ".github/workflows/release.yml")
 
         XCTAssertTrue(workflow.contains("Scripts/package-app.sh"))
         XCTAssertTrue(workflow.contains("shasum -a 256"))
         XCTAssertTrue(workflow.contains("gh release upload"))
-        XCTAssertTrue(workflow.contains("WorkshopWallpaperBridge-macOS-arm64.dmg"))
+        XCTAssertTrue(workflow.contains("-name \"*.dmg\""))
+        XCTAssertTrue(workflow.contains("-name \"*.zip\""))
+        XCTAssertTrue(workflow.contains("RELEASE_ARTIFACT"))
+        XCTAssertTrue(workflow.contains("RELEASE_CHECKSUM"))
         XCTAssertTrue(workflow.contains("contents: write"))
     }
 


### PR DESCRIPTION
## Summary
- detect the actual release archive generated by the checked-out tag
- upload either the generated DMG or legacy ZIP plus its checksum
- update the release workflow documentation test for archive-based publishing

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'
- bash Scripts/package-app.sh
- checksum block exercised against current DMG and legacy ZIP fixture
- swift test --filter DocumentationTests
- swift test

AI-assisted change: Codex diagnosed the failed Release workflow run and prepared this patch.