### PR TITLE
docs: codify maintainer workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,11 +68,15 @@ Before proposing or committing changes, check:
 
 Treat this repository like a public open-source project, even for local agent work.
 
-- Never publish work directly from `main`. Create a focused branch before committing, pushing, opening a PR, or preparing a release.
+- For maintainer, deploy, release, CI/CD, verification, and project-channel requests, use the `$work` workflow so repository work is grounded in the LLM Wiki when it is available.
+- Keep `VAULT_ROOT` and `REPO_ROOT` separate. Resolve wiki memory in this order: `$LLM_WIKI_ROOT` when set, `/workspace/llm-wiki`, then a repo-local `wiki/` only when it exists. Do not fail a deploy or maintainer task merely because this repository has no `wiki/` directory; if no wiki is found, name the searched paths and continue from repository files, GitHub state, and explicit user context.
+- Never publish work directly from `main`. Create a focused branch before committing, pushing, opening a PR, preparing a release, or deploying.
 - Do not commit directly to `main` unless the user explicitly asks for a direct hotfix.
 - Create a focused branch before publishing changes, for example `fix/dock-flicker` or `docs/contribution-workflow`.
 - Keep each branch and pull request scoped to one problem.
 - Use Conventional Commit messages from this file.
+- Maintainer changes must follow this order: update `main`, create the matching branch, make and verify the change, push the branch, open a PR, merge the PR after checks/review, then delete the completed branch.
+- Delete completed branches after merge. Use `Scripts/cleanup-merged-branches.sh origin main` to prune local and remote branches already merged into `origin/main`; the script skips `main`, the current branch, unmerged branches, and branches checked out in another worktree.
 - Before opening a PR, run the required local checks for the touched surface:
   - `swift test` for code changes.
   - `bash Scripts/package-app.sh` for app bundle or release changes.
@@ -93,10 +97,11 @@ When preparing a patch release:
 6. Commit with a `fix:` subject for bug fixes.
 7. Push the branch and open a PR.
 8. Merge the PR into `main`.
-9. Tag the merged commit with the next semantic version:
+9. Delete the completed branch locally and on GitHub, or run `Scripts/cleanup-merged-branches.sh origin main`.
+10. Tag the merged commit with the next semantic version:
    - Patch bug fix: `vMAJOR.MINOR.PATCH`
    - Feature release: `vMAJOR.MINOR.0`
-10. Push the tag. The release workflow builds the DMG, checksum, and GitHub Release.
+11. Push the tag. The release workflow builds the DMG, checksum, and GitHub Release.
 
 Release tags must use the `v<version>` format because `.github/workflows/release.yml` derives the app version from the tag.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,5 +12,6 @@ Quick reminders:
 - Run `swift test` before saying a code change is complete.
 - Update both `README.md` and `README.ko.md` for user-facing behavior changes.
 - Use the commit convention documented in `CONTRIBUTING.md`.
-- Work like an open-source contributor: never publish directly from `main`; create a focused branch, commit with a Conventional Commit subject, push the branch, open a PR with test evidence, merge only after review/checks, then release from a `v<version>` tag.
+- Work like an open-source contributor: use `$work` for maintainer/deploy/release requests, never publish directly from `main`; create a focused branch, commit with a Conventional Commit subject, push the branch, open a PR with test evidence, merge only after review/checks, delete the completed branch, then release from a `v<version>` tag.
+- Resolve LLM Wiki memory from `$LLM_WIKI_ROOT`, `/workspace/llm-wiki`, then repo-local `wiki/`; do not treat this repo's missing `wiki/` directory as a deploy blocker.
 - For patch releases, use the next semantic patch tag, push it after the PR is merged, and let `.github/workflows/release.yml` publish the DMG and checksum.

--- a/Scripts/cleanup-merged-branches.sh
+++ b/Scripts/cleanup-merged-branches.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+remote="${1:-origin}"
+base="${2:-main}"
+base_ref="$remote/$base"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Run this script inside a git work tree." >&2
+  exit 1
+fi
+
+git fetch --prune "$remote"
+
+if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+  echo "Base ref not found: $base_ref" >&2
+  exit 1
+fi
+
+current_branch="$(git branch --show-current)"
+checked_out_branches="$(
+  git worktree list --porcelain |
+    awk '/^branch / { sub("^refs/heads/", "", $2); print $2 }'
+)"
+
+is_checked_out() {
+  local branch="$1"
+  printf '%s\n' "$checked_out_branches" | grep -Fxq "$branch"
+}
+
+is_protected_branch() {
+  case "$1" in
+    "$base" | main | master | develop | trunk)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+echo "Cleaning branches already merged into $base_ref"
+
+while IFS= read -r branch; do
+  [ -n "$branch" ] || continue
+  if is_protected_branch "$branch" || [ "$branch" = "$current_branch" ] || is_checked_out "$branch"; then
+    echo "skip local: $branch"
+    continue
+  fi
+  echo "delete local: $branch"
+  git branch -d "$branch"
+done < <(git for-each-ref --format='%(refname:short)' --merged "$base_ref" refs/heads)
+
+while IFS= read -r ref; do
+  [ -n "$ref" ] || continue
+  case "$ref" in
+    "$remote/HEAD" | "$base_ref")
+      echo "skip remote: $ref"
+      continue
+      ;;
+  esac
+
+  branch="${ref#"$remote/"}"
+  if is_protected_branch "$branch"; then
+    echo "skip remote: $ref"
+    continue
+  fi
+
+  echo "delete remote: $branch"
+  git push "$remote" --delete "$branch"
+done < <(git for-each-ref --format='%(refname:short)' --merged "$base_ref" "refs/remotes/$remote")

--- a/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
+++ b/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
@@ -147,6 +147,31 @@ final class DocumentationTests: XCTestCase {
         XCTAssertTrue(script.contains("com.apple.quarantine"))
     }
 
+    func testMaintainerWorkflowRequiresWorkWikiFallbackAndBranchCleanup() throws {
+        let agents = try String(contentsOfFile: "AGENTS.md")
+        let claude = try String(contentsOfFile: "CLAUDE.md")
+        let maintenance = try String(contentsOfFile: "docs/open-source-maintenance.md")
+        let cleanup = try String(contentsOfFile: "Scripts/cleanup-merged-branches.sh")
+
+        XCTAssertTrue(agents.contains("use the `$work` workflow"))
+        XCTAssertTrue(agents.contains("Keep `VAULT_ROOT` and `REPO_ROOT` separate"))
+        XCTAssertTrue(agents.contains("`$LLM_WIKI_ROOT` when set, `/workspace/llm-wiki`, then a repo-local `wiki/`"))
+        XCTAssertTrue(agents.contains("Do not fail a deploy or maintainer task merely because this repository has no `wiki/` directory"))
+        XCTAssertTrue(agents.contains("push the branch, open a PR, merge the PR after checks/review, then delete the completed branch"))
+        XCTAssertTrue(agents.contains("Scripts/cleanup-merged-branches.sh origin main"))
+
+        XCTAssertTrue(claude.contains("use `$work` for maintainer/deploy/release requests"))
+        XCTAssertTrue(claude.contains("do not treat this repo's missing `wiki/` directory as a deploy blocker"))
+
+        XCTAssertTrue(maintenance.contains("LLM Wiki root resolution"))
+        XCTAssertTrue(maintenance.contains("`Scripts/cleanup-merged-branches.sh`"))
+
+        XCTAssertTrue(cleanup.contains("git fetch --prune \"$remote\""))
+        XCTAssertTrue(cleanup.contains("git branch -d \"$branch\""))
+        XCTAssertTrue(cleanup.contains("git push \"$remote\" --delete \"$branch\""))
+        XCTAssertTrue(cleanup.contains("git worktree list --porcelain"))
+    }
+
     func testPackagedAppDefaultsToCurrentReleaseVersion() throws {
         let script = try String(contentsOfFile: "Scripts/package-app.sh")
 

--- a/docs/open-source-maintenance.md
+++ b/docs/open-source-maintenance.md
@@ -12,7 +12,7 @@ Reasoning: this project is easy to misunderstand as a Steam or Wallpaper Engine 
 
 Purpose: give Codex, Copilot-style agents, and other AI coding tools repo-specific rules.
 
-Reasoning: AI tools often optimize for implementation speed. This project needs extra care around file system safety, Swift concurrency, and honest compatibility claims. `AGENTS.md` makes those constraints explicit.
+Reasoning: AI tools often optimize for implementation speed. This project needs extra care around file system safety, Swift concurrency, honest compatibility claims, and maintainer workflow discipline. `AGENTS.md` makes those constraints explicit, including `$work` usage, LLM Wiki root resolution, branch-per-change work, PR-first publishing, and deleting completed branches after merge.
 
 ## `CLAUDE.md`
 
@@ -53,3 +53,9 @@ Reasoning: this app reads user-selected folders, parses third-party package form
 Purpose: keep history readable.
 
 Reasoning: conventional prefixes such as `fix`, `feat`, `docs`, `test`, and `perf` make release notes and future archaeology easier, especially when outside contributors and AI-generated commits are involved.
+
+## `Scripts/cleanup-merged-branches.sh`
+
+Purpose: remove completed branches after they are merged.
+
+Reasoning: maintainer work should end with a clean repository state. The script fetches and prunes the target remote, then deletes only branches already merged into the configured base branch. It skips protected names, the current branch, unmerged branches, and branches currently checked out in another worktree.


### PR DESCRIPTION
## Summary
- Require $work for maintainer/deploy/release/project-channel work and document LLM Wiki root fallback behavior.
- Codify branch-per-change -> push -> PR -> merge -> branch deletion order.
- Add Scripts/cleanup-merged-branches.sh for completed local/remote branch cleanup.

## Validation
- bash -n Scripts/cleanup-merged-branches.sh
- Scripts/cleanup-merged-branches.sh origin main
- git diff --check
- swift test --filter DocumentationTests was not run: swift is not installed in this headless environment.

## AI Assistance
- AI assistance was used and the final diff was reviewed.