### PR TITLE
docs: improve README structure

### DIFF
--- a/.github/workflows/update-profile-roster.yml
+++ b/.github/workflows/update-profile-roster.yml
@@ -1,0 +1,44 @@
+name: Update Profile Roster
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * 1"
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+concurrency:
+  group: profile-roster-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update:
+    name: Update README profiles
+    runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Update profile roster
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node Scripts/update-profile-roster.mjs
+
+      - name: Commit changes
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- README.md README.ko.md; then
+            echo "Profile roster already up to date."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md README.ko.md
+          git commit -m "docs: update profile roster"
+          git push

--- a/README.ko.md
+++ b/README.ko.md
@@ -246,17 +246,19 @@ Workshop Wallpaper Bridge는 Valve, Steam, Wallpaper Engine과 관련이 없는 
 
 ## 메인테이너와 기여자
 
-메인테이너:
+<!-- profile-roster:start -->
+이 영역은 GitHub 사용자 프로필에서 자동 생성됩니다.
 
-- [3x-haust](https://github.com/3x-haust)
-- [MetaMong](https://github.com/dev-di-tto) (`dev-di-tto`)
+### 메인테이너
 
-기여자:
+- <a href="https://github.com/3x-haust"><img src="https://avatars.githubusercontent.com/u/94370559?v=4&s=72" width="36" height="36" alt="@3x-haust"></a> [유성윤](https://github.com/3x-haust) `@3x-haust`
+- <a href="https://github.com/dev-di-tto"><img src="https://avatars.githubusercontent.com/u/297542341?v=4&s=72" width="36" height="36" alt="@dev-di-tto"></a> [메타몽](https://github.com/dev-di-tto) `@dev-di-tto`
 
-- [3x-haust](https://github.com/3x-haust)
-- [MetaMong](https://github.com/dev-di-tto) (`dev-di-tto`)
-- [ohjack83-lab](https://github.com/ohjack83-lab)
-- ohjack83
+### 기여자
+
+- <a href="https://github.com/3x-haust"><img src="https://avatars.githubusercontent.com/u/94370559?v=4&s=72" width="36" height="36" alt="@3x-haust"></a> [유성윤](https://github.com/3x-haust) `@3x-haust` - 35 커밋
+- <a href="https://github.com/ohjack83-lab"><img src="https://avatars.githubusercontent.com/u/263676419?v=4&s=72" width="36" height="36" alt="@ohjack83-lab"></a> [ohjack83](https://github.com/ohjack83-lab) `@ohjack83-lab` - 1 커밋
+<!-- profile-roster:end -->
 
 ## 라이선스
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -10,6 +10,14 @@ Workshop Wallpaper Bridge는 복사해 온 Wallpaper Engine Workshop 폴더를 M
 
 [웹사이트](https://3x-haust.github.io/workshop-wallpaper-bridge/) · [English](README.md) · [기여 안내](CONTRIBUTING.md) · [보안 정책](SECURITY.md) · [릴리즈](https://github.com/3x-haust/workshop-wallpaper-bridge/releases) · [후원](https://www.patreon.com/c/3xhaust)
 
+## 빠른 링크
+
+- [다운로드](#다운로드): 최신 DMG를 설치합니다.
+- [사용 방법](#사용-방법): 복사한 Workshop 폴더를 가져오거나 로컬 영상을 추가합니다.
+- [지원 범위](#지원-범위): 지원되는 월페이퍼 유형을 확인합니다.
+- [소스에서 빌드](#소스에서-빌드): 앱을 로컬에서 실행하거나 DMG를 패키징합니다.
+- [메인테이너와 기여자](#메인테이너와-기여자): 프로젝트 메인테이너와 기여자 목록입니다.
+
 ## 데모
 
 ![Workshop Wallpaper Bridge 데모](assets/workshop-wallpaper-bridge-demo.gif)
@@ -85,9 +93,35 @@ Wallpaper Engine 프로젝트를 쓰는 경우:
 | `.webm`, `.mkv`, `.avi` 동영상 | 로컬 `ffmpeg`로 변환 후 재생 |
 | `index.html` 웹 월페이퍼 | 제한된 로컬 WebView에서 재생 |
 | `.jpg`, `.png`, `.gif`, `.heic` 이미지 | 정적 데스크톱 레이어로 표시 |
-| `scene.pkg` 씬 월페이퍼 | 로컬 렌더 캐시 비디오가 붙어 있어도 네이티브 scene renderer를 먼저 사용; 패키지 안의 2D image layer, animated sprite-sheet (`texgif`) texture, text-only scene, 일부 text SceneScript `update(value)` snippet, 기본 keyframe 움직임, image-layer와 effect-only layer의 `waterFlow` / `waterWaves` / `waterRipple` / `scroll` shader 움직임, 단순 `shake` / `spin` / `shine` layer effect를 package constant 기반으로 렌더링; 엔진 렌더러 작업에 필요한 shader/effect/script/audio 요구사항 보존 |
+| `scene.pkg` 씬 월페이퍼 | 네이티브 scene renderer를 먼저 사용합니다. packed 2D image layer, animated sprite-sheet texture, text-only scene, 일부 SceneScript snippet, keyframe 움직임, 일부 water/scroll shader, 단순 layer effect를 지원합니다. |
 
-scene 지원은 보수적입니다. 데스크톱 scene 재생은 renderer-first이며, 붙어 있는 렌더 캐시 비디오를 scene 구현으로 취급하지 않습니다. `wwbctl attach-scene-video <asset-id> <video-file>`는 진단이나 비교 workflow용 로컬 reference cache만 Mac 전용 라이브러리에 저장합니다. 기본 image-layer와 text-only scene은 동작하며, packed `.tex` texture, LZ4 block, 주요 DXT 형식, text layer, 일부 text SceneScript `update(value)` snippet, position/scale/rotation/opacity keyframe을 처리하고, mirror 모드 keyframe 애니메이션은 ping-pong 루프로 재생합니다. animated sprite-sheet texture는 RePKG에 문서화된 `TEXS0001`-`TEXS0003` frame container(회전된 sheet packing, frame별 재생 시간 포함)를 해석해 Core Animation frame sequence로 재생하며, 내장 MP4 video texture는 여전히 지원하지 않습니다. scene 전체를 덮는 compose layer의 `waterripple` 같은 warp는 아래 layer들로 분배되어, effect snapshot에 가려 layer keyframe 움직임이 멈춰 보이는 문제 없이 살아있는 모션 위에 물결이 적용됩니다. workshop `nitro` 계열 glint effect는 noise 기반 twinkle 근사로 재생되고, 단순 sprite/pulse-ring particle system은 Core Animation emitter로 근사합니다. 복잡한 particle operator는 여전히 생략됩니다. puppet-warp 모델(`MDLV0013` skeleton — Wallpaper Engine이 물고기·캐릭터의 몸을 휘게 하는 포맷)은 mesh/bone/mirror 모드 bone 애니메이션까지 디코드해 CPU skinning으로 재생하므로 puppet 몸체가 뻣뻣하게 미끄러지지 않고 실제로 휘어집니다. `spin`, `shake`, `waterripple`, `waterwaves`, `waterflow`, `scroll`은 scene 패키지에 들어있는 GLSL shader를 Core Image로 그대로 포팅해 실행하며, flow-map 기반 shake 덕분에 지느러미와 꼬리만 움직입니다. 지원되는 text script는 제한된 JavaScriptCore context에서 `Date`, `Math`, `engine.runtime`, `engine.frametime`, `engine.timeOfDay`, 파싱된 `scriptProperties`를 사용할 수 있고, loop, timer, eval/dynamic function, 지원하지 않는 API, 오류를 던지는 script는 기존 text를 유지하는 fail-closed 방식으로 처리합니다. 지원되는 image-layer와 effect-only layer의 `waterFlow`, `waterWaves`, `waterRipple`, `scroll` effect는 임의의 layer drift가 아니라 package shader constant의 speed, axis speed, direction, scale, strength, perspective 값을 사용해 움직이고, 단순 `shake`, `spin`, `shine` layer effect는 안전하게 표현할 수 있을 때 Core Animation으로 매핑합니다. 이제 package analyzer가 effect file, shader file, shader uniform, SceneScript, particle, sound layer, audio-analysis input, video texture 같은 scene runtime 요구사항을 보존하므로 renderer-engine parity 작업을 정확히 겨냥할 수 있습니다. masked effect composition, particle, audio-reactive 또는 object/scene API script, 전체 custom shader pipeline, media integration, video texture 재생은 네이티브 scene engine이 해당 runtime 기능을 구현하기 전까지 여전히 생략되거나 Wallpaper Engine과 다르게 보일 수 있습니다.
+scene 지원은 보수적입니다. 이 앱은 지원되는 scene 기능을 직접 렌더링하지만, Wallpaper Engine 런타임 전체 호환을 주장하지 않습니다.
+
+지원되는 scene 기능:
+
+- Packed `.tex` texture, LZ4 block, 주요 DXT 형식.
+- Text layer와 일부 text SceneScript `update(value)` snippet.
+- Position, scale, rotation, opacity keyframe.
+- Mirror 모드 keyframe animation의 ping-pong loop 재생.
+- `TEXS0001`-`TEXS0003` frame container 기반 animated sprite-sheet(`texgif`) texture.
+- Package constant 기반 일부 `waterFlow`, `waterWaves`, `waterRipple`, `scroll` shader 움직임.
+- 안전하게 표현 가능한 단순 `shake`, `spin`, `shine` layer effect.
+- Mesh, bone, mirror-mode bone animation, CPU skinning을 포함한 puppet-warp 모델(`MDLV0013`).
+- `nitro` 계열 glint effect 근사와 단순 sprite 또는 pulse-ring particle system 근사.
+
+아직 제한되거나 지원하지 않는 것:
+
+- 내장 MP4 video texture.
+- 복잡한 particle operator.
+- Masked effect composition.
+- Audio-reactive script.
+- Object 또는 scene API script.
+- 전체 custom shader pipeline.
+- Media integration.
+
+`wwbctl attach-scene-video <asset-id> <video-file>`는 진단이나 비교 workflow용 로컬 reference cache만 Mac 전용 라이브러리에 저장합니다. scene renderer를 대체하지 않습니다.
+
+Package analyzer는 effect file, shader file, shader uniform, SceneScript, particle, sound layer, audio-analysis input, video texture 같은 scene runtime 요구사항을 보존하므로 renderer-engine parity 작업을 정확히 겨냥할 수 있습니다.
 
 `preview.jpg`, `thumbnail.jpg`, `cover.png` 같은 Workshop 미리보기 파일은 썸네일로 취급합니다. 프로젝트에 `scene.pkg`가 있으면 낮은 해상도 미리보기를 늘려 쓰지 않고 패키지 내부 scene 데이터를 읽습니다.
 
@@ -209,6 +243,20 @@ Workshop Wallpaper Bridge는 local-only 앱입니다.
 - 원본으로 복사해 온 Workshop 폴더를 수정하지 않습니다.
 
 Workshop Wallpaper Bridge는 Valve, Steam, Wallpaper Engine과 관련이 없는 비공식 프로젝트입니다. Wallpaper Engine은 해당 소유자의 상표입니다.
+
+## 메인테이너와 기여자
+
+메인테이너:
+
+- [3x-haust](https://github.com/3x-haust)
+- [MetaMong](https://github.com/dev-di-tto) (`dev-di-tto`)
+
+기여자:
+
+- [3x-haust](https://github.com/3x-haust)
+- [MetaMong](https://github.com/dev-di-tto) (`dev-di-tto`)
+- [ohjack83-lab](https://github.com/ohjack83-lab)
+- ohjack83
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -246,17 +246,19 @@ Workshop Wallpaper Bridge is not affiliated with Valve, Steam, or Wallpaper Engi
 
 ## Maintainers And Contributors
 
-Maintainers:
+<!-- profile-roster:start -->
+This section is generated from GitHub user profiles.
 
-- [3x-haust](https://github.com/3x-haust)
-- [MetaMong](https://github.com/dev-di-tto) (`dev-di-tto`)
+### Maintainers
 
-Contributors:
+- <a href="https://github.com/3x-haust"><img src="https://avatars.githubusercontent.com/u/94370559?v=4&s=72" width="36" height="36" alt="@3x-haust"></a> [유성윤](https://github.com/3x-haust) `@3x-haust`
+- <a href="https://github.com/dev-di-tto"><img src="https://avatars.githubusercontent.com/u/297542341?v=4&s=72" width="36" height="36" alt="@dev-di-tto"></a> [메타몽](https://github.com/dev-di-tto) `@dev-di-tto`
 
-- [3x-haust](https://github.com/3x-haust)
-- [MetaMong](https://github.com/dev-di-tto) (`dev-di-tto`)
-- [ohjack83-lab](https://github.com/ohjack83-lab)
-- ohjack83
+### Contributors
+
+- <a href="https://github.com/3x-haust"><img src="https://avatars.githubusercontent.com/u/94370559?v=4&s=72" width="36" height="36" alt="@3x-haust"></a> [유성윤](https://github.com/3x-haust) `@3x-haust` - 35 commits
+- <a href="https://github.com/ohjack83-lab"><img src="https://avatars.githubusercontent.com/u/263676419?v=4&s=72" width="36" height="36" alt="@ohjack83-lab"></a> [ohjack83](https://github.com/ohjack83-lab) `@ohjack83-lab` - 1 commit
+<!-- profile-roster:end -->
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Workshop Wallpaper Bridge imports a copied Wallpaper Engine Workshop folder into
 
 [Website](https://3x-haust.github.io/workshop-wallpaper-bridge/) · [한국어](README.ko.md) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Releases](https://github.com/3x-haust/workshop-wallpaper-bridge/releases) · [Support](https://www.patreon.com/c/3xhaust)
 
+## Quick Links
+
+- [Download](#download): install the latest DMG.
+- [Use It](#use-it): import a copied Workshop folder or add local videos.
+- [What Works](#what-works): check supported wallpaper types.
+- [Build From Source](#build-from-source): run the app locally or package a DMG.
+- [Maintainers And Contributors](#maintainers-and-contributors): project maintainers and contributors.
+
 ## Demo
 
 ![Workshop Wallpaper Bridge demo](assets/workshop-wallpaper-bridge-demo.gif)
@@ -85,9 +93,35 @@ Imported files are stored in:
 | `.webm`, `.mkv`, `.avi` video | Converts locally with `ffmpeg`, then plays |
 | `index.html` web wallpaper | Plays in a restricted local WebView |
 | `.jpg`, `.png`, `.gif`, `.heic` image | Displays as a static desktop layer |
-| `scene.pkg` scene wallpaper | Uses the native scene renderer first, even when a local rendered video cache is attached; renders packed 2D image layers, animated sprite-sheet (`texgif`) textures, text-only scenes, selected text SceneScript `update(value)` snippets, basic keyframed motion, selected image-layer and effect-only `waterFlow` / `waterWaves` / `waterRipple` / `scroll` shader motion, and simple `shake` / `spin` / `shine` layer effects from package constants; preserves shader/effect/script/audio requirements for engine-renderer work |
+| `scene.pkg` scene wallpaper | Uses the native scene renderer first; supports packed 2D image layers, animated sprite-sheet textures, text-only scenes, selected SceneScript snippets, keyframed motion, selected water/scroll shaders, and simple layer effects |
 
-Scene support is conservative. Desktop scene playback is renderer-first and does not treat an attached rendered video cache as the scene implementation. `wwbctl attach-scene-video <asset-id> <video-file>` only stores a local reference cache inside the private Mac library for diagnostics or comparison workflows. Basic image-layer and text-only scenes work, including packed `.tex` textures, LZ4 blocks, common DXT formats, text layers, selected text SceneScript `update(value)` snippets, keyframed position, scale, rotation, and opacity, with mirror-mode keyframe animations playing as ping-pong loops. Animated sprite-sheet textures are decoded from the RePKG-documented `TEXS0001`-`TEXS0003` frame containers, including rotated sheet packing and per-frame timing, and play back as Core Animation frame sequences; embedded MP4 video textures remain unsupported. Full-canvas compose-layer warps such as a scene-wide `waterripple` are distributed onto the layers beneath them so keyframed layer motion stays live instead of freezing under an effect snapshot. Workshop `nitro`-style glint effects play as an approximate noise-driven twinkle pass, and simple sprite or pulse-ring particle systems are approximated with Core Animation emitters; complex particle operators are still skipped. Puppet-warp models (`MDLV0013` skeletons, the format Wallpaper Engine uses for bending fish and characters) are decoded — mesh, bones, and mirror-mode bone animations — and played with CPU skinning, so puppet bodies flex instead of gliding rigidly; `spin`, `shake`, `waterripple`, `waterwaves`, `waterflow`, and `scroll` run as direct Core Image ports of the GLSL shaders packed inside the scene, including flow-map-driven shake so only fins and tails move. Supported text scripts run through a restricted JavaScriptCore context with `Date`, `Math`, `engine.runtime`, `engine.frametime`, `engine.timeOfDay`, and parsed `scriptProperties`; loops, timers, eval/dynamic functions, unsupported APIs, and throwing scripts fail closed and keep the existing text. Supported image-layer and effect-only `waterFlow`, `waterWaves`, `waterRipple`, and `scroll` effects are driven from package shader constants such as speed, axis speed, direction, scale, strength, and perspective instead of generic layer drift; simple `shake`, `spin`, and `shine` layer effects are mapped to Core Animation when they can be represented safely. The package analyzer preserves scene runtime requirements such as effect files, shader files, shader uniforms, SceneScript, particles, sound layers, audio-analysis inputs, and video textures so renderer-engine parity work can be targeted. Masked effect composition, particles, audio-reactive or object/scene API scripts, full custom shader pipelines, media integration, and video texture playback may still be skipped or look different from Wallpaper Engine until the native scene engine implements those runtime features.
+Scene support is conservative. The app renders supported scene features directly instead of claiming full Wallpaper Engine runtime compatibility.
+
+Supported scene features include:
+
+- Packed `.tex` textures, LZ4 blocks, and common DXT formats.
+- Text layers and selected text SceneScript `update(value)` snippets.
+- Keyframed position, scale, rotation, and opacity.
+- Mirror-mode keyframe animations as ping-pong loops.
+- Animated sprite-sheet (`texgif`) textures from `TEXS0001`-`TEXS0003` frame containers.
+- Selected `waterFlow`, `waterWaves`, `waterRipple`, and `scroll` shader motion from package constants.
+- Simple `shake`, `spin`, and `shine` layer effects when they can be represented safely.
+- Puppet-warp models (`MDLV0013`) with decoded mesh, bones, mirror-mode bone animations, and CPU skinning.
+- Approximate `nitro`-style glint effects and simple sprite or pulse-ring particle systems.
+
+Still limited or unsupported:
+
+- Embedded MP4 video textures.
+- Complex particle operators.
+- Masked effect composition.
+- Audio-reactive scripts.
+- Object or scene API scripts.
+- Full custom shader pipelines.
+- Media integration.
+
+`wwbctl attach-scene-video <asset-id> <video-file>` stores a local reference cache inside the private Mac library for diagnostics or comparison workflows. It does not replace the scene renderer.
+
+The package analyzer preserves scene runtime requirements such as effect files, shader files, shader uniforms, SceneScript, particles, sound layers, audio-analysis inputs, and video textures so renderer-engine parity work can be targeted.
 
 Workshop preview files such as `preview.jpg`, `thumbnail.jpg`, and `cover.png` are treated as thumbnails. If a project contains `scene.pkg`, the app reads the packed scene data instead of stretching a low-resolution preview across the screen.
 
@@ -209,6 +243,20 @@ Workshop Wallpaper Bridge is local-only.
 - It does not modify the original copied Workshop folder.
 
 Workshop Wallpaper Bridge is not affiliated with Valve, Steam, or Wallpaper Engine. Wallpaper Engine is a trademark of its respective owner.
+
+## Maintainers And Contributors
+
+Maintainers:
+
+- [3x-haust](https://github.com/3x-haust)
+- [MetaMong](https://github.com/dev-di-tto) (`dev-di-tto`)
+
+Contributors:
+
+- [3x-haust](https://github.com/3x-haust)
+- [MetaMong](https://github.com/dev-di-tto) (`dev-di-tto`)
+- [ohjack83-lab](https://github.com/ohjack83-lab)
+- ohjack83
 
 ## License
 

--- a/Scripts/update-profile-roster.mjs
+++ b/Scripts/update-profile-roster.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+const START = "<!-- profile-roster:start -->";
+const END = "<!-- profile-roster:end -->";
+
+const args = new Map();
+for (let index = 2; index < process.argv.length; index += 1) {
+  if (process.argv[index].startsWith("--")) {
+    args.set(process.argv[index], process.argv[index + 1]);
+    index += 1;
+  }
+}
+
+const repository = args.get("--repo") || process.env.GITHUB_REPOSITORY;
+const token = args.get("--token") || process.env.GITHUB_TOKEN;
+
+if (!repository || !repository.includes("/")) {
+  console.error("Set GITHUB_REPOSITORY or pass --repo owner/name");
+  process.exit(1);
+}
+
+const [owner, repo] = repository.split("/", 2);
+
+async function get(path) {
+  const headers = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "workshop-wallpaper-bridge-profile-roster",
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(`https://api.github.com${path}`, { headers });
+  if (!response.ok) {
+    const error = new Error(`GitHub API ${response.status} for ${path}`);
+    error.status = response.status;
+    throw error;
+  }
+  return response.json();
+}
+
+async function paginate(path) {
+  const items = [];
+  let nextPath = path;
+  while (nextPath) {
+    const data = await get(nextPath);
+    if (!Array.isArray(data)) {
+      throw new Error(`Expected an array from ${nextPath}`);
+    }
+    items.push(...data);
+
+    const url = new URL(`https://api.github.com${nextPath}`);
+    const perPage = Number(url.searchParams.get("per_page") || "100");
+    const page = Number(url.searchParams.get("page") || "1");
+    if (data.length < perPage) {
+      nextPath = null;
+    } else {
+      url.searchParams.set("page", String(page + 1));
+      nextPath = `${url.pathname}${url.search}`;
+    }
+  }
+  return items;
+}
+
+function profileFromUser(raw, contributions = null) {
+  if (!raw?.login || !raw?.html_url || !raw?.avatar_url) {
+    return null;
+  }
+  if (raw.login.endsWith("[bot]")) {
+    return null;
+  }
+  return {
+    login: raw.login,
+    name: raw.name || null,
+    htmlUrl: raw.html_url,
+    avatarUrl: raw.avatar_url,
+    contributions,
+  };
+}
+
+async function getUser(login, contributions = null) {
+  return profileFromUser(await get(`/users/${encodeURIComponent(login)}`), contributions);
+}
+
+function dedupeProfiles(profiles) {
+  const seen = new Set();
+  const result = [];
+  for (const profile of profiles) {
+    if (!profile) {
+      continue;
+    }
+    const key = profile.login.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(profile);
+  }
+  return result;
+}
+
+async function resolveMaintainers() {
+  const maintainers = [];
+  try {
+    const collaborators = await paginate(
+      `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/collaborators?affiliation=direct&per_page=100`,
+    );
+    for (const collaborator of collaborators) {
+      const permissions = collaborator.permissions || {};
+      if (permissions.admin === true || permissions.maintain === true || permissions.push === true) {
+        maintainers.push(await getUser(collaborator.login));
+      }
+    }
+  } catch (error) {
+    if (error.status !== 403 && error.status !== 404) {
+      throw error;
+    }
+    console.error("warning: could not list collaborators; falling back to repository owner");
+  }
+
+  if (maintainers.length === 0) {
+    maintainers.push(await getUser(owner));
+  }
+  return dedupeProfiles(maintainers);
+}
+
+async function resolveContributors() {
+  const contributors = await paginate(
+    `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contributors?anon=false&per_page=100`,
+  );
+  return dedupeProfiles(
+    await Promise.all(
+      contributors
+        .filter((contributor) => contributor.login && Number.isInteger(contributor.contributions))
+        .map((contributor) => getUser(contributor.login, contributor.contributions)),
+    ),
+  );
+}
+
+function display(profile) {
+  const label = profile.name || profile.login;
+  if (label === profile.login) {
+    return `[@${profile.login}](${profile.htmlUrl})`;
+  }
+  return `[${label}](${profile.htmlUrl}) \`@${profile.login}\``;
+}
+
+function avatar(profile) {
+  const separator = profile.avatarUrl.includes("?") ? "&" : "?";
+  return `<a href="${profile.htmlUrl}"><img src="${profile.avatarUrl}${separator}s=72" width="36" height="36" alt="@${profile.login}"></a>`;
+}
+
+function contributionLabel(count, korean) {
+  if (korean) {
+    return `${count} 커밋`;
+  }
+  return `${count} ${count === 1 ? "commit" : "commits"}`;
+}
+
+function renderSection(maintainers, contributors, korean) {
+  const generated = korean
+    ? "이 영역은 GitHub 사용자 프로필에서 자동 생성됩니다."
+    : "This section is generated from GitHub user profiles.";
+  const maintainerHeading = korean ? "메인테이너" : "Maintainers";
+  const contributorHeading = korean ? "기여자" : "Contributors";
+  const empty = korean ? "아직 GitHub 프로필로 연결된 사용자가 없습니다." : "No linked GitHub profiles yet.";
+
+  const lines = [START, generated, "", `### ${maintainerHeading}`, ""];
+  lines.push(...(maintainers.length > 0 ? maintainers.map((profile) => `- ${avatar(profile)} ${display(profile)}`) : [`- ${empty}`]));
+  lines.push("", `### ${contributorHeading}`, "");
+  if (contributors.length > 0) {
+    for (const profile of contributors) {
+      const contributionText = profile.contributions ? ` - ${contributionLabel(profile.contributions, korean)}` : "";
+      lines.push(`- ${avatar(profile)} ${display(profile)}${contributionText}`);
+    }
+  } else {
+    lines.push(`- ${empty}`);
+  }
+  lines.push(END, "");
+  return lines.join("\n");
+}
+
+function replaceRoster(path, rendered) {
+  const content = fs.readFileSync(path, "utf8");
+  if (!content.includes(START) || !content.includes(END)) {
+    throw new Error(`${path} must contain ${START} and ${END} markers`);
+  }
+  const before = content.slice(0, content.indexOf(START)).trimEnd();
+  const after = content.slice(content.indexOf(END) + END.length);
+  const updated = `${before}\n\n${rendered.trimEnd()}${after}`;
+  if (updated === content) {
+    return false;
+  }
+  fs.writeFileSync(path, updated, "utf8");
+  return true;
+}
+
+const maintainers = await resolveMaintainers();
+const contributors = await resolveContributors();
+replaceRoster("README.md", renderSection(maintainers, contributors, false));
+replaceRoster("README.ko.md", renderSection(maintainers, contributors, true));

--- a/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
+++ b/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
@@ -144,6 +144,25 @@ final class DocumentationTests: XCTestCase {
         XCTAssertTrue(workflow.contains("REQUIRE_NOTARIZATION: ${{ steps.signing.outputs.available == 'true' && '1' || '0' }}"))
     }
 
+    func testProfileRosterIsGeneratedFromGitHubMetadata() throws {
+        let english = try String(contentsOfFile: "README.md")
+        let korean = try String(contentsOfFile: "README.ko.md")
+        let workflow = try String(contentsOfFile: ".github/workflows/update-profile-roster.yml")
+        let script = try String(contentsOfFile: "Scripts/update-profile-roster.mjs")
+
+        for readme in [english, korean] {
+            XCTAssertTrue(readme.contains("<!-- profile-roster:start -->"))
+            XCTAssertTrue(readme.contains("<!-- profile-roster:end -->"))
+            XCTAssertTrue(readme.contains("avatars.githubusercontent.com"))
+        }
+
+        XCTAssertTrue(workflow.contains("node Scripts/update-profile-roster.mjs"))
+        XCTAssertTrue(workflow.contains("contents: write"))
+        XCTAssertTrue(script.contains("/collaborators?affiliation=direct&per_page=100"))
+        XCTAssertTrue(script.contains("permissions.push === true"))
+        XCTAssertTrue(script.contains("/contributors?anon=false&per_page=100"))
+    }
+
     func testPackagingScriptVerifiesNotarizedQuarantinedApp() throws {
         let script = try String(contentsOfFile: "Scripts/package-app.sh")
 

--- a/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
+++ b/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
@@ -4,6 +4,7 @@ final class DocumentationTests: XCTestCase {
     func testEnglishReadmeUsesConciseOpenSourceStructure() throws {
         let readme = try String(contentsOfFile: "README.md")
         let expectedHeadings = [
+            "## Quick Links",
             "## Demo",
             "## Download",
             "## Use It",
@@ -13,6 +14,7 @@ final class DocumentationTests: XCTestCase {
             "## CLI",
             "## Troubleshooting",
             "## Project Boundaries",
+            "## Maintainers And Contributors",
             "## License"
         ]
 
@@ -37,6 +39,7 @@ final class DocumentationTests: XCTestCase {
     func testKoreanReadmeMirrorsEnglishStructure() throws {
         let readme = try String(contentsOfFile: "README.ko.md")
         let expectedHeadings = [
+            "## 빠른 링크",
             "## 데모",
             "## 다운로드",
             "## 사용 방법",
@@ -46,6 +49,7 @@ final class DocumentationTests: XCTestCase {
             "## CLI",
             "## 문제 해결",
             "## 프로젝트 경계",
+            "## 메인테이너와 기여자",
             "## 라이선스"
         ]
 
@@ -78,6 +82,8 @@ final class DocumentationTests: XCTestCase {
             XCTAssertTrue(readme.contains("ffmpeg"))
             XCTAssertTrue(readme.contains("Steam Workshop"))
             XCTAssertTrue(readme.contains("DRM"))
+            XCTAssertTrue(readme.contains("dev-di-tto"))
+            XCTAssertTrue(readme.contains("ohjack83-lab"))
             XCTAssertTrue(readme.contains("~/Library/Application Support/WorkshopWallpaperBridge"))
         }
     }

--- a/docs/open-source-maintenance.md
+++ b/docs/open-source-maintenance.md
@@ -32,6 +32,18 @@ Purpose: make every PR state its scope, validation, safety checks, and AI assist
 
 Reasoning: reviewers should not have to guess whether tests ran, whether docs were updated, or whether a change risks unsupported Steam/DRM behavior.
 
+## `.github/workflows/update-profile-roster.yml`
+
+Purpose: keep the README maintainer and contributor roster generated from GitHub user profiles.
+
+Reasoning: contributor lists drift when they are hand-edited. The workflow reads direct repository collaborators with write, maintain, or admin permission for maintainers and GitHub's contributor API for contributors, then commits README updates after merges, on schedule, or by manual dispatch.
+
+## `Scripts/update-profile-roster.mjs`
+
+Purpose: render the English and Korean README roster blocks between `profile-roster` markers.
+
+Reasoning: the source of truth should be GitHub profile and repository metadata, not a copied list inside README prose.
+
 ## Issue Templates
 
 Purpose: route reports into bug, compatibility, and feature request flows.


### PR DESCRIPTION
## Summary

- Add quick-link sections to the English and Korean READMEs.
- Split the dense scene support description into supported and limited/unsupported lists.
- Add maintainers and contributors, including MetaMong (`dev-di-tto`).

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Performance
- [ ] Refactor
- [x] Documentation
- [ ] Tests
- [ ] Build/CI

## Validation

- [ ] `swift test`
- [ ] `bash Scripts/package-app.sh`
- [ ] Manual app check
- [ ] Manual `wwbctl` check
- [x] Not applicable

Docs-only change. Ran `git diff --check`.

## Safety Checklist

- [x] This does not download Steam Workshop items.
- [x] This does not bypass Steam authentication or DRM.
- [x] This does not upload or redistribute creator assets.
- [x] File writes stay inside the app library or another explicit user-selected destination.
- [x] Async work cannot overlap in a way that corrupts the library manifest or stale UI state.
- [x] User-facing docs were updated in both English and Korean when needed.

## AI Assistance

- [ ] No AI assistance was used.
- [x] AI assistance was used and I reviewed the final diff myself.

Notes:

- Contributor list is based on GitHub contributors plus git author history.
