### PR TITLE
fix: open profile roster updates as pull requests

### DIFF
--- a/.github/workflows/update-profile-roster.yml
+++ b/.github/workflows/update-profile-roster.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: profile-roster-${{ github.ref }}
@@ -31,14 +32,35 @@ jobs:
         run: node Scripts/update-profile-roster.mjs
 
       - name: Commit changes
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           if git diff --quiet -- README.md README.ko.md; then
             echo "Profile roster already up to date."
             exit 0
           fi
+          branch="automation/update-profile-roster"
+          git fetch origin "${branch}:refs/remotes/origin/${branch}" || true
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add README.md README.ko.md
           git commit -m "docs: update profile roster"
-          git push
+          git push --force-with-lease origin "HEAD:${branch}"
+          existing_pr="$(gh pr list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --head "${branch}" \
+            --base main \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')"
+          if [ -n "${existing_pr}" ]; then
+            echo "Profile roster pull request already exists."
+          else
+            gh pr create \
+              --repo "${GITHUB_REPOSITORY}" \
+              --head "${branch}" \
+              --base main \
+              --title "docs: update README profile roster" \
+              --body "Updates the generated maintainer and contributor roster in README.md and README.ko.md."
+          fi

--- a/README.ko.md
+++ b/README.ko.md
@@ -258,6 +258,7 @@ Workshop Wallpaper Bridge는 Valve, Steam, Wallpaper Engine과 관련이 없는 
 
 - <a href="https://github.com/3x-haust"><img src="https://avatars.githubusercontent.com/u/94370559?v=4&s=72" width="36" height="36" alt="@3x-haust"></a> [유성윤](https://github.com/3x-haust) `@3x-haust` - 35 커밋
 - <a href="https://github.com/ohjack83-lab"><img src="https://avatars.githubusercontent.com/u/263676419?v=4&s=72" width="36" height="36" alt="@ohjack83-lab"></a> [ohjack83](https://github.com/ohjack83-lab) `@ohjack83-lab` - 1 커밋
+- <a href="https://github.com/dev-di-tto"><img src="https://avatars.githubusercontent.com/u/297542341?v=4&s=72" width="36" height="36" alt="@dev-di-tto"></a> [메타몽](https://github.com/dev-di-tto) `@dev-di-tto` - 1 커밋
 <!-- profile-roster:end -->
 
 ## 라이선스

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ This section is generated from GitHub user profiles.
 
 - <a href="https://github.com/3x-haust"><img src="https://avatars.githubusercontent.com/u/94370559?v=4&s=72" width="36" height="36" alt="@3x-haust"></a> [유성윤](https://github.com/3x-haust) `@3x-haust` - 35 commits
 - <a href="https://github.com/ohjack83-lab"><img src="https://avatars.githubusercontent.com/u/263676419?v=4&s=72" width="36" height="36" alt="@ohjack83-lab"></a> [ohjack83](https://github.com/ohjack83-lab) `@ohjack83-lab` - 1 commit
+- <a href="https://github.com/dev-di-tto"><img src="https://avatars.githubusercontent.com/u/297542341?v=4&s=72" width="36" height="36" alt="@dev-di-tto"></a> [메타몽](https://github.com/dev-di-tto) `@dev-di-tto` - 1 commit
 <!-- profile-roster:end -->
 
 ## License

--- a/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
+++ b/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
@@ -158,6 +158,9 @@ final class DocumentationTests: XCTestCase {
 
         XCTAssertTrue(workflow.contains("node Scripts/update-profile-roster.mjs"))
         XCTAssertTrue(workflow.contains("contents: write"))
+        XCTAssertTrue(workflow.contains("pull-requests: write"))
+        XCTAssertTrue(workflow.contains("automation/update-profile-roster"))
+        XCTAssertTrue(workflow.contains("gh pr create"))
         XCTAssertTrue(script.contains("/collaborators?affiliation=direct&per_page=100"))
         XCTAssertTrue(script.contains("permissions.push === true"))
         XCTAssertTrue(script.contains("/contributors?anon=false&per_page=100"))

--- a/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
+++ b/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
@@ -149,6 +149,7 @@ final class DocumentationTests: XCTestCase {
         let korean = try String(contentsOfFile: "README.ko.md")
         let workflow = try String(contentsOfFile: ".github/workflows/update-profile-roster.yml")
         let script = try String(contentsOfFile: "Scripts/update-profile-roster.mjs")
+        let maintenanceNotes = try String(contentsOfFile: "docs/open-source-maintenance.md")
 
         for readme in [english, korean] {
             XCTAssertTrue(readme.contains("<!-- profile-roster:start -->"))
@@ -161,6 +162,7 @@ final class DocumentationTests: XCTestCase {
         XCTAssertTrue(workflow.contains("pull-requests: write"))
         XCTAssertTrue(workflow.contains("automation/update-profile-roster"))
         XCTAssertTrue(workflow.contains("gh pr create"))
+        XCTAssertTrue(maintenanceNotes.contains("creates or reuses a pull request"))
         XCTAssertTrue(script.contains("/collaborators?affiliation=direct&per_page=100"))
         XCTAssertTrue(script.contains("permissions.push === true"))
         XCTAssertTrue(script.contains("/contributors?anon=false&per_page=100"))

--- a/docs/open-source-maintenance.md
+++ b/docs/open-source-maintenance.md
@@ -36,7 +36,7 @@ Reasoning: reviewers should not have to guess whether tests ran, whether docs we
 
 Purpose: keep the README maintainer and contributor roster generated from GitHub user profiles.
 
-Reasoning: contributor lists drift when they are hand-edited. The workflow reads direct repository collaborators with write, maintain, or admin permission for maintainers and GitHub's contributor API for contributors, then commits README updates after merges, on schedule, or by manual dispatch.
+Reasoning: contributor lists drift when they are hand-edited. The workflow reads direct repository collaborators with write, maintain, or admin permission for maintainers and GitHub's contributor API for contributors, then pushes README updates to `automation/update-profile-roster` and creates or reuses a pull request after merges, on schedule, or by manual dispatch.
 
 ## `Scripts/update-profile-roster.mjs`
 


### PR DESCRIPTION
## Summary
- change the generated README profile roster workflow to push updates to an automation branch instead of main
- create or reuse a PR for generated README.md and README.ko.md changes
- add documentation coverage for the PR-based update path

## Validation
- node --check Scripts/update-profile-roster.mjs
- GITHUB_REPOSITORY=3x-haust/workshop-wallpaper-bridge node Scripts/update-profile-roster.mjs
- git diff --check

Swift tests were not run locally because this Ubuntu environment does not have Swift installed.