### PR TITLE
fix: stabilize profile roster pull requests

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -256,9 +256,9 @@ Workshop Wallpaper Bridge는 Valve, Steam, Wallpaper Engine과 관련이 없는 
 
 ### 기여자
 
-- <a href="https://github.com/3x-haust"><img src="https://avatars.githubusercontent.com/u/94370559?v=4&s=72" width="36" height="36" alt="@3x-haust"></a> [유성윤](https://github.com/3x-haust) `@3x-haust` - 35 커밋
-- <a href="https://github.com/dev-di-tto"><img src="https://avatars.githubusercontent.com/u/297542341?v=4&s=72" width="36" height="36" alt="@dev-di-tto"></a> [메타몽](https://github.com/dev-di-tto) `@dev-di-tto` - 2 커밋
-- <a href="https://github.com/ohjack83-lab"><img src="https://avatars.githubusercontent.com/u/263676419?v=4&s=72" width="36" height="36" alt="@ohjack83-lab"></a> [ohjack83](https://github.com/ohjack83-lab) `@ohjack83-lab` - 1 커밋
+- <a href="https://github.com/3x-haust"><img src="https://avatars.githubusercontent.com/u/94370559?v=4&s=72" width="36" height="36" alt="@3x-haust"></a> [유성윤](https://github.com/3x-haust) `@3x-haust`
+- <a href="https://github.com/dev-di-tto"><img src="https://avatars.githubusercontent.com/u/297542341?v=4&s=72" width="36" height="36" alt="@dev-di-tto"></a> [메타몽](https://github.com/dev-di-tto) `@dev-di-tto`
+- <a href="https://github.com/ohjack83-lab"><img src="https://avatars.githubusercontent.com/u/263676419?v=4&s=72" width="36" height="36" alt="@ohjack83-lab"></a> [ohjack83](https://github.com/ohjack83-lab) `@ohjack83-lab`
 <!-- profile-roster:end -->
 
 ## 라이선스

--- a/README.md
+++ b/README.md
@@ -256,9 +256,9 @@ This section is generated from GitHub user profiles.
 
 ### Contributors
 
-- <a href="https://github.com/3x-haust"><img src="https://avatars.githubusercontent.com/u/94370559?v=4&s=72" width="36" height="36" alt="@3x-haust"></a> [유성윤](https://github.com/3x-haust) `@3x-haust` - 35 commits
-- <a href="https://github.com/dev-di-tto"><img src="https://avatars.githubusercontent.com/u/297542341?v=4&s=72" width="36" height="36" alt="@dev-di-tto"></a> [메타몽](https://github.com/dev-di-tto) `@dev-di-tto` - 2 commits
-- <a href="https://github.com/ohjack83-lab"><img src="https://avatars.githubusercontent.com/u/263676419?v=4&s=72" width="36" height="36" alt="@ohjack83-lab"></a> [ohjack83](https://github.com/ohjack83-lab) `@ohjack83-lab` - 1 commit
+- <a href="https://github.com/3x-haust"><img src="https://avatars.githubusercontent.com/u/94370559?v=4&s=72" width="36" height="36" alt="@3x-haust"></a> [유성윤](https://github.com/3x-haust) `@3x-haust`
+- <a href="https://github.com/dev-di-tto"><img src="https://avatars.githubusercontent.com/u/297542341?v=4&s=72" width="36" height="36" alt="@dev-di-tto"></a> [메타몽](https://github.com/dev-di-tto) `@dev-di-tto`
+- <a href="https://github.com/ohjack83-lab"><img src="https://avatars.githubusercontent.com/u/263676419?v=4&s=72" width="36" height="36" alt="@ohjack83-lab"></a> [ohjack83](https://github.com/ohjack83-lab) `@ohjack83-lab`
 <!-- profile-roster:end -->
 
 ## License

--- a/Scripts/update-profile-roster.mjs
+++ b/Scripts/update-profile-roster.mjs
@@ -153,13 +153,6 @@ function avatar(profile) {
   return `<a href="${profile.htmlUrl}"><img src="${profile.avatarUrl}${separator}s=72" width="36" height="36" alt="@${profile.login}"></a>`;
 }
 
-function contributionLabel(count, korean) {
-  if (korean) {
-    return `${count} 커밋`;
-  }
-  return `${count} ${count === 1 ? "commit" : "commits"}`;
-}
-
 function renderSection(maintainers, contributors, korean) {
   const generated = korean
     ? "이 영역은 GitHub 사용자 프로필에서 자동 생성됩니다."
@@ -173,8 +166,7 @@ function renderSection(maintainers, contributors, korean) {
   lines.push("", `### ${contributorHeading}`, "");
   if (contributors.length > 0) {
     for (const profile of contributors) {
-      const contributionText = profile.contributions ? ` - ${contributionLabel(profile.contributions, korean)}` : "";
-      lines.push(`- ${avatar(profile)} ${display(profile)}${contributionText}`);
+      lines.push(`- ${avatar(profile)} ${display(profile)}`);
     }
   } else {
     lines.push(`- ${empty}`);

--- a/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
+++ b/Tests/WorkshopWallpaperCoreTests/DocumentationTests.swift
@@ -163,9 +163,11 @@ final class DocumentationTests: XCTestCase {
         XCTAssertTrue(workflow.contains("automation/update-profile-roster"))
         XCTAssertTrue(workflow.contains("gh pr create"))
         XCTAssertTrue(maintenanceNotes.contains("creates or reuses a pull request"))
+        XCTAssertTrue(maintenanceNotes.contains("intentionally omits commit counts"))
         XCTAssertTrue(script.contains("/collaborators?affiliation=direct&per_page=100"))
         XCTAssertTrue(script.contains("permissions.push === true"))
         XCTAssertTrue(script.contains("/contributors?anon=false&per_page=100"))
+        XCTAssertFalse(script.contains("contributionLabel"))
     }
 
     func testPackagingScriptVerifiesNotarizedQuarantinedApp() throws {

--- a/docs/open-source-maintenance.md
+++ b/docs/open-source-maintenance.md
@@ -36,7 +36,7 @@ Reasoning: reviewers should not have to guess whether tests ran, whether docs we
 
 Purpose: keep the README maintainer and contributor roster generated from GitHub user profiles.
 
-Reasoning: contributor lists drift when they are hand-edited. The workflow reads direct repository collaborators with write, maintain, or admin permission for maintainers and GitHub's contributor API for contributors, then pushes README updates to `automation/update-profile-roster` and creates or reuses a pull request after merges, on schedule, or by manual dispatch.
+Reasoning: contributor lists drift when they are hand-edited. The workflow reads direct repository collaborators with write, maintain, or admin permission for maintainers and GitHub's contributor API for contributors, then pushes README profile updates to `automation/update-profile-roster` and creates or reuses a pull request after merges, on schedule, or by manual dispatch. The generated roster intentionally omits commit counts so merging a roster-only pull request does not immediately make the roster stale again.
 
 ## `Scripts/update-profile-roster.mjs`
 


### PR DESCRIPTION
## Summary
- omit generated contributor commit counts so roster-only PR merges do not immediately stale the roster again
- regenerate README.md and README.ko.md profile rosters without counts
- document and test the count-free PR-based update path

## Validation
- node --check Scripts/update-profile-roster.mjs
- GITHUB_REPOSITORY=3x-haust/workshop-wallpaper-bridge node Scripts/update-profile-roster.mjs
- git diff --check

Swift tests were not run locally because this Ubuntu environment does not have Swift installed.