### PR TITLE
fix: run library import off the main thread with progress

### DIFF
--- a/Sources/WorkshopWallpaperBridgeApp/AppViewModel.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/AppViewModel.swift
@@ -9,6 +9,12 @@ struct UpdateAlert: Identifiable {
     let message: String
 }
 
+struct ImportProgress: Equatable {
+    let completed: Int
+    let total: Int
+    var fraction: Double { total > 0 ? Double(completed) / Double(total) : 0 }
+}
+
 @MainActor
 protocol WallpaperPlaying: AnyObject {
     func play(
@@ -32,6 +38,7 @@ final class AppViewModel: ObservableObject {
     @Published private(set) var selectedLibraryAssetIds: Set<WallpaperAsset.ID> = []
     @Published var status = "Choose a copied Wallpaper Engine Workshop folder to begin."
     @Published var isWorking = false
+    @Published private(set) var importProgress: ImportProgress?
     @Published var displayMode: WallpaperDisplayMode = .fit {
         didSet {
             wallpaperPlayer.setDisplayMode(displayMode)
@@ -264,31 +271,45 @@ extension AppViewModel {
         }
     }
 
-    func importSelected() {
+    @discardableResult
+    func importSelected() -> Task<Void, Never> {
         let assets = selectedScannedAssets
         guard !assets.isEmpty else {
             status = "Select a scanned project first."
-            return
+            return Task {}
         }
-        var importedAssets: [WallpaperAsset] = []
-        do {
-            for asset in assets {
-                importedAssets.append(try store.importAsset(asset))
+        // Copy files off the main thread so the UI stays responsive, and report
+        // per-item progress so a large multi-import never looks frozen.
+        isWorking = true
+        importProgress = ImportProgress(completed: 0, total: assets.count)
+        status = "Importing 0/\(assets.count)..."
+        let store = self.store
+        return Task {
+            var importedAssets: [WallpaperAsset] = []
+            do {
+                for asset in assets {
+                    let imported = try await Task.detached { try store.importAsset(asset) }.value
+                    importedAssets.append(imported)
+                    importProgress = ImportProgress(completed: importedAssets.count, total: assets.count)
+                    status = "Importing \(importedAssets.count)/\(assets.count)..."
+                }
+                loadLibrary()
+                selectLibraryAssets(Set(importedAssets.map(\.id)))
+                if importedAssets.count == 1, let imported = importedAssets.first {
+                    status = "Imported \(imported.title)."
+                } else {
+                    status = "Imported \(importedAssets.count) projects."
+                }
+            } catch {
+                loadLibrary()
+                if importedAssets.isEmpty {
+                    status = error.localizedDescription
+                } else {
+                    status = "Imported \(importedAssets.count) project(s), then failed: \(error.localizedDescription)"
+                }
             }
-            loadLibrary()
-            selectLibraryAssets(Set(importedAssets.map(\.id)))
-            if importedAssets.count == 1, let imported = importedAssets.first {
-                status = "Imported \(imported.title)."
-            } else {
-                status = "Imported \(importedAssets.count) projects."
-            }
-        } catch {
-            loadLibrary()
-            if importedAssets.isEmpty {
-                status = error.localizedDescription
-            } else {
-                status = "Imported \(importedAssets.count) project(s), then failed: \(error.localizedDescription)"
-            }
+            importProgress = nil
+            isWorking = false
         }
     }
 
@@ -304,16 +325,23 @@ extension AppViewModel {
         }
     }
 
-    func importVideoFile(_ url: URL) {
-        do {
-            let imported = try store.importVideoFile(url)
-            loadLibrary()
-            selectedLibraryAssetId = imported.id
-            status = imported.supportStatus == .needsConversion
-                ? "Added \(imported.title). Convert it before playing."
-                : "Added \(imported.title)."
-        } catch {
-            status = error.localizedDescription
+    @discardableResult
+    func importVideoFile(_ url: URL) -> Task<Void, Never> {
+        isWorking = true
+        status = "Adding \(url.lastPathComponent)..."
+        let store = self.store
+        return Task {
+            do {
+                let imported = try await Task.detached { try store.importVideoFile(url) }.value
+                loadLibrary()
+                selectedLibraryAssetId = imported.id
+                status = imported.supportStatus == .needsConversion
+                    ? "Added \(imported.title). Convert it before playing."
+                    : "Added \(imported.title)."
+            } catch {
+                status = error.localizedDescription
+            }
+            isWorking = false
         }
     }
 

--- a/Sources/WorkshopWallpaperBridgeApp/ContentView.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/ContentView.swift
@@ -105,7 +105,7 @@ struct ContentView: View {
                 Button(importButtonTitle) {
                     model.importSelected()
                 }
-                .disabled(model.selectedScannedAssetIds.isEmpty)
+                .disabled(model.selectedScannedAssetIds.isEmpty || model.isWorking)
                 Spacer()
             }
         }
@@ -234,7 +234,11 @@ struct ContentView: View {
 
     private var statusBar: some View {
         HStack {
-            if model.isWorking {
+            if let progress = model.importProgress {
+                ProgressView(value: progress.fraction)
+                    .controlSize(.small)
+                    .frame(width: 120)
+            } else if model.isWorking {
                 ProgressView()
                     .controlSize(.small)
             }

--- a/Tests/WorkshopWallpaperBridgeAppTests/AppViewModelTests.swift
+++ b/Tests/WorkshopWallpaperBridgeAppTests/AppViewModelTests.swift
@@ -5,7 +5,7 @@ import WorkshopWallpaperCore
 
 @MainActor
 final class AppViewModelTests: XCTestCase {
-    func testImportSelectedImportsMultipleScannedAssets() throws {
+    func testImportSelectedImportsMultipleScannedAssets() async throws {
         // Given
         let sourceRoot = try makeTempDirectory()
         let first = try makeScannedProject(root: sourceRoot, id: "first", title: "First Loop")
@@ -19,9 +19,13 @@ final class AppViewModelTests: XCTestCase {
         model.scannedAssets = [first, second]
         model.selectScannedAssets([first.id, second.id])
 
-        // When
-        model.importSelected()
+        // When (import runs off the main thread; await its completion)
+        await model.importSelected().value
         let manifest = try store.load()
+
+        // Then the working/progress state is cleared once the import finishes.
+        XCTAssertFalse(model.isWorking)
+        XCTAssertNil(model.importProgress)
 
         // Then
         XCTAssertEqual(Set(manifest.assets.map(\.id)), [first.id, second.id])


### PR DESCRIPTION
## Summary

- 라이브러리 Import가 파일 복사를 **메인 스레드에서 동기로** 수행해서, 복사가 끝날 때까지 UI 전체가 멈췄습니다(응답 없음). 여러 개를 한 번에 Import하거나, 클라우드 동기화 폴더에서 큰 영상을 읽어올 때 특히 오래 멈춰 보여서, 사용자가 앱이 hang된 줄 알고 강제 종료할 수 있었습니다.
- 파일 복사를 detached task로 옮겨(기존 영상 변환 플로우와 동일 패턴) UI를 응답 가능하게 하고, 항목별 `ImportProgress`를 publish 해서 상태 바에 **진행 막대 + "Importing 3/9..."** 를 표시합니다. 작업 중에는 Import 버튼을 비활성화합니다.
- `importVideoFile`도 같은 방식으로 비동기화했습니다.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Performance
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Build/CI

## Validation

- [x] `swift build` — 통과
- [ ] `bash Scripts/package-app.sh`
- [x] Manual app check — 다수 Import 시 진행 막대/카운트 표시, UI 응답 유지 확인
- [ ] Manual `wwbctl` check
- [ ] Not applicable

> 작성 환경이 Command Line Tools라 `swift test`를 로컬에서 돌리지 못했습니다(XCTest 모듈 없음). 기존 `testImportSelectedImportsMultipleScannedAssets`를 async로 바꿔 Task 완료를 await 하고, 완료 후 `isWorking`/`importProgress`가 정리되는지 검증을 추가했습니다. CI(macOS + Xcode)에서 `swift test` 실행 부탁드립니다.

## Safety Checklist

- [x] This does not download Steam Workshop items.
- [x] This does not bypass Steam authentication or DRM.
- [x] This does not upload or redistribute creator assets.
- [x] File writes stay inside the app library or another explicit user-selected destination. (복사 대상/동작 동일, 스레드만 이동)
- [x] Async work cannot overlap in a way that corrupts the library manifest or stale UI state. (Import 중 버튼 비활성 + 완료 시 상태 정리, 기존 convert 플로우와 동일 패턴)
- [x] User-facing docs were updated in both English and Korean when needed. (동작 동일, UI 문구만 추가라 문서 변경 없음 — 필요하면 반영하겠습니다)

## 구현 메모

- 기존 `convertSelected()`의 `isWorking = true` + `Task { try await Task.detached { ... }.value; ...; isWorking = false }` 패턴을 그대로 따랐습니다. `LibraryStore`는 `Sendable` struct, `WallpaperAsset`도 `Sendable`이라 detached에서 안전합니다.
- `importSelected()` / `importVideoFile()`는 `@discardableResult`로 `Task<Void, Never>`를 반환해, UI 호출부는 그대로 두면서 테스트에서 `.value`로 완료를 await 할 수 있게 했습니다.

## AI Assistance

- [ ] No AI assistance was used.
- [x] AI assistance was used and I reviewed the final diff myself.
