### PR TITLE
Add Date Added sorting for scanned wallpapers

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -54,6 +54,11 @@ Wallpaper Engine 프로젝트를 쓰는 경우:
 5. 지원되는 항목을 선택하고 **Import Selected**를 누릅니다.
 6. **Play on Desktop**을 누릅니다.
 
+스캔 목록은 기본적으로 macOS 폴더 **Date Added** 값을 기준으로 최신순 정렬됩니다.
+Date Added를 읽을 수 없으면 수정일을 fallback으로 사용합니다. 알파벳순으로 보고 싶으면
+정렬을 **Name**으로 바꿀 수 있습니다. Import 이후 새로 복사되어 다음 Scan에서 발견된
+항목에는 **NEW** 배지가 붙습니다.
+
 직접 가진 영상을 쓰려면 Workshop 폴더를 스캔하지 않고 **Add Video File**을 누릅니다.
 
 표시 방식:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ For Wallpaper Engine projects:
 5. Select a supported item and click **Import Selected**.
 6. Click **Play on Desktop**.
 
+The scan list sorts by **Date Added** newest first by default, using the macOS
+folder Date Added value with modification date as a fallback. Switch the sort to
+**Name** when you want an alphabetical list. After you import, items added to
+the copied Workshop folder later are marked **NEW** on the next scan.
+
 For your own videos, click **Add Video File** instead of scanning a Workshop folder.
 
 Display modes:

--- a/Sources/WorkshopWallpaperBridgeApp/AppViewModel.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/AppViewModel.swift
@@ -9,6 +9,22 @@ struct UpdateAlert: Identifiable {
     let message: String
 }
 
+enum ScannedAssetSortOrder: String, CaseIterable, Identifiable {
+    case dateAdded
+    case name
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .dateAdded:
+            "Date Added"
+        case .name:
+            "Name"
+        }
+    }
+}
+
 @MainActor
 protocol WallpaperPlaying: AnyObject {
     func play(
@@ -112,6 +128,15 @@ final class AppViewModel: ObservableObject {
             if rotationEnabled {
                 restartRotationTimer()
             }
+        }
+    }
+    @Published var scannedSortOrder: ScannedAssetSortOrder = .dateAdded {
+        didSet {
+            guard scannedSortOrder != oldValue else {
+                return
+            }
+            userDefaults.set(scannedSortOrder.rawValue, forKey: PreferenceKey.scannedSortOrder)
+            sortScannedAssets()
         }
     }
 
@@ -256,8 +281,8 @@ extension AppViewModel {
         }
         do {
             let result = try scanner.scan(root: URL(filePath: sourcePath))
-            scannedAssets = result.assets
-            selectedScannedAssetIds = result.assets.first.map { Set([$0.id]) } ?? []
+            scannedAssets = sortedScannedAssets(result.assets)
+            selectedScannedAssetIds = scannedAssets.first.map { Set([$0.id]) } ?? []
             status = "Found \(result.assets.count) project(s)."
         } catch {
             status = error.localizedDescription
@@ -275,6 +300,7 @@ extension AppViewModel {
             for asset in assets {
                 importedAssets.append(try store.importAsset(asset))
             }
+            userDefaults.set(Date(), forKey: PreferenceKey.lastImportAt)
             loadLibrary()
             selectLibraryAssets(Set(importedAssets.map(\.id)))
             if importedAssets.count == 1, let imported = importedAssets.first {
@@ -579,9 +605,33 @@ extension AppViewModel {
         if userDefaults.object(forKey: PreferenceKey.rotationShuffle) != nil {
             rotationShuffle = userDefaults.bool(forKey: PreferenceKey.rotationShuffle)
         }
+        if let rawScannedSortOrder = userDefaults.string(forKey: PreferenceKey.scannedSortOrder),
+           let storedScannedSortOrder = ScannedAssetSortOrder(rawValue: rawScannedSortOrder) {
+            scannedSortOrder = storedScannedSortOrder
+        }
         let storedRotationInterval = userDefaults.double(forKey: PreferenceKey.rotationInterval)
         if storedRotationInterval > 0 {
             rotationInterval = storedRotationInterval
+        }
+    }
+
+    private func sortScannedAssets() {
+        scannedAssets = sortedScannedAssets(scannedAssets)
+        normalizeScannedSelection(allowEmpty: true)
+    }
+
+    private func sortedScannedAssets(_ assets: [WallpaperAsset]) -> [WallpaperAsset] {
+        switch scannedSortOrder {
+        case .dateAdded:
+            assets.sorted(by: dateAddedSort)
+        case .name:
+            assets.sorted { lhs, rhs in
+                let titleOrder = lhs.title.localizedStandardCompare(rhs.title)
+                if titleOrder != .orderedSame {
+                    return titleOrder == .orderedAscending
+                }
+                return lhs.id.localizedStandardCompare(rhs.id) == .orderedAscending
+            }
         }
     }
 
@@ -669,9 +719,18 @@ extension AppViewModel {
             entrypoint: output.path,
             thumbnail: asset.thumbnail,
             workshopId: asset.workshopId,
+            dateAdded: asset.dateAdded,
             redistributionAllowed: false,
             issues: asset.issues.filter { $0.code != "needs_conversion" }
         )
+    }
+
+    func isNewScannedAsset(_ asset: WallpaperAsset) -> Bool {
+        guard let lastImportAt = userDefaults.object(forKey: PreferenceKey.lastImportAt) as? Date,
+              let dateAdded = asset.dateAdded else {
+            return false
+        }
+        return dateAdded > lastImportAt
     }
 
     private func scheduleAutomaticUpdateCheck(force: Bool = false) {
@@ -847,4 +906,19 @@ private enum PreferenceKey {
     static let rotationEnabled = "rotationEnabled"
     static let rotationShuffle = "rotationShuffle"
     static let rotationInterval = "rotationInterval"
+    static let scannedSortOrder = "scannedSortOrder"
+    static let lastImportAt = "lastImportAt"
+}
+
+private func dateAddedSort(_ lhs: WallpaperAsset, _ rhs: WallpaperAsset) -> Bool {
+    switch (lhs.dateAdded, rhs.dateAdded) {
+    case let (left?, right?) where left != right:
+        return left > right
+    case (_?, nil):
+        return true
+    case (nil, _?):
+        return false
+    default:
+        return lhs.id.localizedStandardCompare(rhs.id) == .orderedAscending
+    }
 }

--- a/Sources/WorkshopWallpaperBridgeApp/ContentView.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/ContentView.swift
@@ -92,10 +92,23 @@ struct ContentView: View {
                     model.scanSource()
                 }
             }
+            HStack {
+                Text("Scanned Projects")
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                Picker("Sort", selection: $model.scannedSortOrder) {
+                    ForEach(ScannedAssetSortOrder.allCases) { order in
+                        Text(order.title).tag(order)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 220)
+            }
             assetList(
                 title: "Scanned Projects",
                 assets: model.scannedAssets,
                 previewAsset: model.selectedScannedAsset,
+                isNew: { model.isNewScannedAsset($0) },
                 selection: Binding(
                     get: { model.selectedScannedAssetIds },
                     set: { model.selectScannedAssets($0) }
@@ -137,6 +150,7 @@ struct ContentView: View {
                 title: "Imported Projects",
                 assets: model.libraryAssets,
                 previewAsset: model.selectedLibraryAsset,
+                isNew: { _ in false },
                 selection: Binding(
                     get: { model.selectedLibraryAssetIds },
                     set: { model.selectLibraryAssets($0) }
@@ -250,12 +264,13 @@ struct ContentView: View {
         title: String,
         assets: [WallpaperAsset],
         previewAsset: WallpaperAsset?,
+        isNew: @escaping (WallpaperAsset) -> Bool,
         selection: Binding<Set<WallpaperAsset.ID>>
     ) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             List(selection: selection) {
                 ForEach(assets) { asset in
-                    AssetRow(asset: asset)
+                    AssetRow(asset: asset, isNew: isNew(asset))
                         .tag(asset.id)
                 }
             }
@@ -274,12 +289,13 @@ struct ContentView: View {
         title: String,
         assets: [WallpaperAsset],
         previewAsset: WallpaperAsset?,
+        isNew: @escaping (WallpaperAsset) -> Bool,
         selection: Binding<Set<WallpaperAsset.ID>>
     ) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             List(selection: selection) {
                 ForEach(assets) { asset in
-                    AssetRow(asset: asset)
+                    AssetRow(asset: asset, isNew: isNew(asset))
                         .tag(asset.id)
                         .contextMenu {
                             Button("Remove") {
@@ -345,6 +361,7 @@ private struct AssetPreview: View {
 
 private struct AssetRow: View {
     let asset: WallpaperAsset
+    let isNew: Bool
 
     var body: some View {
         HStack(spacing: 10) {
@@ -365,6 +382,20 @@ private struct AssetRow: View {
                 }
             }
             Spacer()
+            if isNew {
+                Text("NEW")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(Color.accentColor))
+            }
+            if let dateAddedText {
+                Text(dateAddedText)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
             Text(asset.kind.rawValue)
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -374,6 +405,20 @@ private struct AssetRow: View {
         }
         .padding(.vertical, 4)
     }
+
+    private var dateAddedText: String? {
+        guard let dateAdded = asset.dateAdded else {
+            return nil
+        }
+        return Self.dateFormatter.string(from: dateAdded)
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter
+    }()
 }
 
 private struct AssetThumbnail: View {

--- a/Sources/WorkshopWallpaperCore/LibraryStore.swift
+++ b/Sources/WorkshopWallpaperCore/LibraryStore.swift
@@ -79,7 +79,6 @@ public struct LibraryStore: Sendable {
             entrypoint: entrypoint.path,
             thumbnail: nil,
             workshopId: nil,
-            dateAdded: Date(),
             redistributionAllowed: false,
             issues: []
         )

--- a/Sources/WorkshopWallpaperCore/LibraryStore.swift
+++ b/Sources/WorkshopWallpaperCore/LibraryStore.swift
@@ -79,6 +79,7 @@ public struct LibraryStore: Sendable {
             entrypoint: entrypoint.path,
             thumbnail: nil,
             workshopId: nil,
+            dateAdded: Date(),
             redistributionAllowed: false,
             issues: []
         )
@@ -170,6 +171,7 @@ public struct LibraryStore: Sendable {
             entrypoint: asset.entrypoint,
             thumbnail: asset.thumbnail,
             workshopId: asset.workshopId,
+            dateAdded: asset.dateAdded,
             redistributionAllowed: false,
             issues: mergedIssues(asset.issues + [cacheIssue])
         )
@@ -276,6 +278,7 @@ public struct LibraryStore: Sendable {
             entrypoint: rewrite(path: asset.entrypoint, source: source, target: target),
             thumbnail: rewrite(path: asset.thumbnail, source: source, target: target),
             workshopId: asset.workshopId,
+            dateAdded: asset.dateAdded,
             redistributionAllowed: false,
             issues: asset.issues
         )
@@ -326,6 +329,7 @@ public struct LibraryStore: Sendable {
             entrypoint: scanned.entrypoint,
             thumbnail: scanned.thumbnail ?? asset.thumbnail,
             workshopId: asset.workshopId,
+            dateAdded: asset.dateAdded ?? scanned.dateAdded,
             redistributionAllowed: false,
             issues: mergedIssues(asset.issues + scanned.issues)
         )
@@ -371,6 +375,7 @@ public struct LibraryStore: Sendable {
             entrypoint: asset.entrypoint,
             thumbnail: asset.thumbnail,
             workshopId: asset.workshopId,
+            dateAdded: asset.dateAdded,
             redistributionAllowed: hasRenderCache ? false : asset.redistributionAllowed,
             issues: mergedIssues(preserved + refreshed + cacheIssues)
         )

--- a/Sources/WorkshopWallpaperCore/Models.swift
+++ b/Sources/WorkshopWallpaperCore/Models.swift
@@ -41,6 +41,7 @@ public struct WallpaperAsset: Codable, Equatable, Identifiable, Sendable {
     public let entrypoint: String?
     public let thumbnail: String?
     public let workshopId: String?
+    public let dateAdded: Date?
     public let redistributionAllowed: Bool
     public let issues: [ScanIssue]
 
@@ -54,6 +55,7 @@ public struct WallpaperAsset: Codable, Equatable, Identifiable, Sendable {
         entrypoint: String?,
         thumbnail: String?,
         workshopId: String?,
+        dateAdded: Date? = nil,
         redistributionAllowed: Bool,
         issues: [ScanIssue]
     ) {
@@ -66,6 +68,7 @@ public struct WallpaperAsset: Codable, Equatable, Identifiable, Sendable {
         self.entrypoint = entrypoint
         self.thumbnail = thumbnail
         self.workshopId = workshopId
+        self.dateAdded = dateAdded
         self.redistributionAllowed = redistributionAllowed
         self.issues = issues
     }

--- a/Sources/WorkshopWallpaperCore/Scanner.swift
+++ b/Sources/WorkshopWallpaperCore/Scanner.swift
@@ -7,7 +7,7 @@ public struct WallpaperScanner: Sendable {
         let projects = try discoverProjects(root: root.standardizedFileURL)
         let assets = try projects
             .map { try scanProject(root: root.standardizedFileURL, project: $0) }
-            .sorted { $0.id.localizedStandardCompare($1.id) == .orderedAscending }
+            .sorted(by: dateAddedSort)
         return ScanResult(root: root.path, generatedAt: Date(), assets: assets)
     }
 
@@ -18,7 +18,7 @@ public struct WallpaperScanner: Sendable {
         return try FileManager.default
             .contentsOfDirectory(
                 at: root,
-                includingPropertiesForKeys: [.isDirectoryKey],
+                includingPropertiesForKeys: [.isDirectoryKey, .addedToDirectoryDateKey, .contentModificationDateKey],
                 options: [.skipsHiddenFiles]
             )
             .filter { isDirectory($0) && isProjectDirectory($0) }
@@ -42,6 +42,7 @@ public struct WallpaperScanner: Sendable {
             entrypoint: entry?.path,
             thumbnail: thumbnail?.path,
             workshopId: id.allSatisfy(\.isNumber) ? id : nil,
+            dateAdded: dateAdded(for: project),
             redistributionAllowed: false,
             issues: issues
         )
@@ -214,6 +215,11 @@ public struct WallpaperScanner: Sendable {
         }
         return .manualFolder
     }
+
+    private func dateAdded(for project: URL) -> Date? {
+        let values = try? project.resourceValues(forKeys: [.addedToDirectoryDateKey, .contentModificationDateKey])
+        return values?.addedToDirectoryDate ?? values?.contentModificationDate
+    }
 }
 
 private struct ProjectMetadata: Decodable {
@@ -264,6 +270,19 @@ private func entrypointRank(_ url: URL) -> Int {
     if imageExtensions.contains(ext) { return 3 }
     if ext == "pkg" { return 4 }
     return 5
+}
+
+private func dateAddedSort(_ lhs: WallpaperAsset, _ rhs: WallpaperAsset) -> Bool {
+    switch (lhs.dateAdded, rhs.dateAdded) {
+    case let (left?, right?) where left != right:
+        return left > right
+    case (_?, nil):
+        return true
+    case (nil, _?):
+        return false
+    default:
+        return lhs.id.localizedStandardCompare(rhs.id) == .orderedAscending
+    }
 }
 
 private func isDirectory(_ url: URL) -> Bool {

--- a/Tests/WorkshopWallpaperBridgeAppTests/AppViewModelTests.swift
+++ b/Tests/WorkshopWallpaperBridgeAppTests/AppViewModelTests.swift
@@ -54,6 +54,68 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertEqual(model.selectedScannedAssetId, asset.id)
     }
 
+    func testScanSourceSortsByDateAddedByDefaultAndCanSortByName() throws {
+        // Given
+        let sourceRoot = try makeTempDirectory()
+        let older = try makeScannedProject(root: sourceRoot, id: "100", title: "Alpha")
+        let newer = try makeScannedProject(root: sourceRoot, id: "200", title: "Beta")
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 1_700_000_000)],
+            ofItemAtPath: older.projectDirectory
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 1_700_086_400)],
+            ofItemAtPath: newer.projectDirectory
+        )
+        let model = AppViewModel(
+            store: LibraryStore(root: try makeTempDirectory()),
+            loginItemController: MockLoginItemController(),
+            userDefaults: try makeUserDefaults()
+        )
+        model.sourcePath = sourceRoot.path
+
+        // When
+        model.scanSource()
+
+        // Then
+        XCTAssertEqual(model.scannedAssets.map(\.id), ["200", "100"])
+        XCTAssertEqual(model.selectedScannedAssetId, "200")
+
+        // When
+        model.scannedSortOrder = .name
+
+        // Then
+        XCTAssertEqual(model.scannedAssets.map(\.id), ["100", "200"])
+    }
+
+    func testNewScannedAssetUsesLastImportBaseline() throws {
+        // Given
+        let sourceRoot = try makeTempDirectory()
+        let old = try makeScannedProject(
+            root: sourceRoot,
+            id: "old",
+            title: "Old",
+            dateAdded: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let fresh = try makeScannedProject(
+            root: sourceRoot,
+            id: "fresh",
+            title: "Fresh",
+            dateAdded: Date(timeIntervalSince1970: 1_700_010_000)
+        )
+        let defaults = try makeUserDefaults()
+        defaults.set(Date(timeIntervalSince1970: 1_700_005_000), forKey: "lastImportAt")
+        let model = AppViewModel(
+            store: LibraryStore(root: try makeTempDirectory()),
+            loginItemController: MockLoginItemController(),
+            userDefaults: defaults
+        )
+
+        // Then
+        XCTAssertFalse(model.isNewScannedAsset(old))
+        XCTAssertTrue(model.isNewScannedAsset(fresh))
+    }
+
     func testInitSelectsFirstLibraryAssetWhenAvailable() throws {
         // Given
         let sourceRoot = try makeTempDirectory()
@@ -417,11 +479,21 @@ final class AppViewModelTests: XCTestCase {
         return defaults
     }
 
-    private func makeScannedProject(root: URL, id: String, title: String) throws -> WallpaperAsset {
+    private func makeScannedProject(
+        root: URL,
+        id: String,
+        title: String,
+        dateAdded: Date? = nil
+    ) throws -> WallpaperAsset {
         let project = root.appending(path: id)
         try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
         let entrypoint = project.appending(path: "loop.mp4")
         try Data([1]).write(to: entrypoint)
+        try #"{"title":"\#(title)","file":"loop.mp4"}"#.write(
+            to: project.appending(path: "project.json"),
+            atomically: true,
+            encoding: .utf8
+        )
         return WallpaperAsset(
             id: id,
             title: title,
@@ -432,6 +504,7 @@ final class AppViewModelTests: XCTestCase {
             entrypoint: entrypoint.path,
             thumbnail: nil,
             workshopId: id,
+            dateAdded: dateAdded,
             redistributionAllowed: false,
             issues: []
         )

--- a/Tests/WorkshopWallpaperCoreTests/ScannerTests.swift
+++ b/Tests/WorkshopWallpaperCoreTests/ScannerTests.swift
@@ -32,18 +32,20 @@ final class ScannerTests: XCTestCase {
     func testScanReadsDateAddedAndSortsNewestFirst() throws {
         // Given
         let root = try Fixture.makeTempDirectory()
-        let older = try Fixture.project(
+        try Fixture.project(
             root: root,
             id: "100",
             metadata: #"{"title":"Older","file":"older.mp4"}"#,
             file: "older.mp4"
         )
-        let newer = try Fixture.project(
+        try Fixture.project(
             root: root,
             id: "200",
             metadata: #"{"title":"Newer","file":"newer.mp4"}"#,
             file: "newer.mp4"
         )
+        let older = root.appending(path: "100")
+        let newer = root.appending(path: "200")
         let olderDate = Date(timeIntervalSince1970: 1_700_000_000)
         let newerDate = Date(timeIntervalSince1970: 1_700_086_400)
         try FileManager.default.setAttributes([.modificationDate: olderDate], ofItemAtPath: older.path)

--- a/Tests/WorkshopWallpaperCoreTests/ScannerTests.swift
+++ b/Tests/WorkshopWallpaperCoreTests/ScannerTests.swift
@@ -29,6 +29,35 @@ final class ScannerTests: XCTestCase {
         XCTAssertEqual(asset.redistributionAllowed, false)
     }
 
+    func testScanReadsDateAddedAndSortsNewestFirst() throws {
+        // Given
+        let root = try Fixture.makeTempDirectory()
+        let older = try Fixture.project(
+            root: root,
+            id: "100",
+            metadata: #"{"title":"Older","file":"older.mp4"}"#,
+            file: "older.mp4"
+        )
+        let newer = try Fixture.project(
+            root: root,
+            id: "200",
+            metadata: #"{"title":"Newer","file":"newer.mp4"}"#,
+            file: "newer.mp4"
+        )
+        let olderDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let newerDate = Date(timeIntervalSince1970: 1_700_086_400)
+        try FileManager.default.setAttributes([.modificationDate: olderDate], ofItemAtPath: older.path)
+        try FileManager.default.setAttributes([.modificationDate: newerDate], ofItemAtPath: newer.path)
+
+        // When
+        let result = try WallpaperScanner().scan(root: root)
+
+        // Then
+        XCTAssertEqual(result.assets.map(\.id), ["200", "100"])
+        XCTAssertNotNil(result.assets[0].dateAdded)
+        XCTAssertNotNil(result.assets[1].dateAdded)
+    }
+
     func testScanClassifiesWebImageAndSceneProjects() throws {
         // Given
         let root = try Fixture.makeTempDirectory()

--- a/Tests/WorkshopWallpaperCoreTests/ScannerTests.swift
+++ b/Tests/WorkshopWallpaperCoreTests/ScannerTests.swift
@@ -86,8 +86,10 @@ final class ScannerTests: XCTestCase {
         let result = try WallpaperScanner().scan(root: root)
 
         // Then
-        XCTAssertEqual(result.assets.map(\.kind), [.image, .scene, .web])
-        XCTAssertEqual(result.assets.map(\.supportStatus), [.playable, .unsupported, .playable])
+        let supportByKind = Dictionary(uniqueKeysWithValues: result.assets.map { ($0.kind, $0.supportStatus) })
+        XCTAssertEqual(supportByKind[.image], .playable)
+        XCTAssertEqual(supportByKind[.scene], .unsupported)
+        XCTAssertEqual(supportByKind[.web], .playable)
     }
 
     func testScanReportsMalformedProjectJsonWithoutThrowing() throws {


### PR DESCRIPTION
## Summary
- store optional `dateAdded` metadata on scanned/imported wallpaper assets
- sort scanned projects by Date Added by default, with a Name sort toggle
- mark scanned projects as NEW when their Date Added is after the last import baseline
- document the scan sorting and NEW badge behavior in English and Korean READMEs

## Verification
- `git diff --check`
- `swift test` not run locally: Swift toolchain is unavailable in this Ubuntu/headless environment

Closes #38