### PR TITLE
fix: prevent overlapping library imports

### DIFF
--- a/Sources/WorkshopWallpaperBridgeApp/AppViewModel.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/AppViewModel.swift
@@ -9,6 +9,12 @@ struct UpdateAlert: Identifiable {
     let message: String
 }
 
+struct ImportProgress: Equatable {
+    let completed: Int
+    let total: Int
+    var fraction: Double { total > 0 ? Double(completed) / Double(total) : 0 }
+}
+
 @MainActor
 protocol WallpaperPlaying: AnyObject {
     func play(
@@ -32,6 +38,7 @@ final class AppViewModel: ObservableObject {
     @Published private(set) var selectedLibraryAssetIds: Set<WallpaperAsset.ID> = []
     @Published var status = "Choose a copied Wallpaper Engine Workshop folder to begin."
     @Published var isWorking = false
+    @Published private(set) var importProgress: ImportProgress?
     @Published var displayMode: WallpaperDisplayMode = .fit {
         didSet {
             wallpaperPlayer.setDisplayMode(displayMode)
@@ -264,31 +271,45 @@ extension AppViewModel {
         }
     }
 
-    func importSelected() {
+    @discardableResult
+    func importSelected() -> Task<Void, Never> {
         let assets = selectedScannedAssets
         guard !assets.isEmpty else {
             status = "Select a scanned project first."
-            return
+            return Task {}
         }
-        var importedAssets: [WallpaperAsset] = []
-        do {
-            for asset in assets {
-                importedAssets.append(try store.importAsset(asset))
+        // Copy files off the main thread so the UI stays responsive, and report
+        // per-item progress so a large multi-import never looks frozen.
+        isWorking = true
+        importProgress = ImportProgress(completed: 0, total: assets.count)
+        status = "Importing 0/\(assets.count)..."
+        let store = self.store
+        return Task {
+            var importedAssets: [WallpaperAsset] = []
+            do {
+                for asset in assets {
+                    let imported = try await Task.detached { try store.importAsset(asset) }.value
+                    importedAssets.append(imported)
+                    importProgress = ImportProgress(completed: importedAssets.count, total: assets.count)
+                    status = "Importing \(importedAssets.count)/\(assets.count)..."
+                }
+                loadLibrary()
+                selectLibraryAssets(Set(importedAssets.map(\.id)))
+                if importedAssets.count == 1, let imported = importedAssets.first {
+                    status = "Imported \(imported.title)."
+                } else {
+                    status = "Imported \(importedAssets.count) projects."
+                }
+            } catch {
+                loadLibrary()
+                if importedAssets.isEmpty {
+                    status = error.localizedDescription
+                } else {
+                    status = "Imported \(importedAssets.count) project(s), then failed: \(error.localizedDescription)"
+                }
             }
-            loadLibrary()
-            selectLibraryAssets(Set(importedAssets.map(\.id)))
-            if importedAssets.count == 1, let imported = importedAssets.first {
-                status = "Imported \(imported.title)."
-            } else {
-                status = "Imported \(importedAssets.count) projects."
-            }
-        } catch {
-            loadLibrary()
-            if importedAssets.isEmpty {
-                status = error.localizedDescription
-            } else {
-                status = "Imported \(importedAssets.count) project(s), then failed: \(error.localizedDescription)"
-            }
+            importProgress = nil
+            isWorking = false
         }
     }
 
@@ -304,16 +325,23 @@ extension AppViewModel {
         }
     }
 
-    func importVideoFile(_ url: URL) {
-        do {
-            let imported = try store.importVideoFile(url)
-            loadLibrary()
-            selectedLibraryAssetId = imported.id
-            status = imported.supportStatus == .needsConversion
-                ? "Added \(imported.title). Convert it before playing."
-                : "Added \(imported.title)."
-        } catch {
-            status = error.localizedDescription
+    @discardableResult
+    func importVideoFile(_ url: URL) -> Task<Void, Never> {
+        isWorking = true
+        status = "Adding \(url.lastPathComponent)..."
+        let store = self.store
+        return Task {
+            do {
+                let imported = try await Task.detached { try store.importVideoFile(url) }.value
+                loadLibrary()
+                selectedLibraryAssetId = imported.id
+                status = imported.supportStatus == .needsConversion
+                    ? "Added \(imported.title). Convert it before playing."
+                    : "Added \(imported.title)."
+            } catch {
+                status = error.localizedDescription
+            }
+            isWorking = false
         }
     }
 

--- a/Sources/WorkshopWallpaperBridgeApp/ContentView.swift
+++ b/Sources/WorkshopWallpaperBridgeApp/ContentView.swift
@@ -105,7 +105,7 @@ struct ContentView: View {
                 Button(importButtonTitle) {
                     model.importSelected()
                 }
-                .disabled(model.selectedScannedAssetIds.isEmpty)
+                .disabled(model.selectedScannedAssetIds.isEmpty || model.isWorking)
                 Spacer()
             }
         }
@@ -234,7 +234,11 @@ struct ContentView: View {
 
     private var statusBar: some View {
         HStack {
-            if model.isWorking {
+            if let progress = model.importProgress {
+                ProgressView(value: progress.fraction)
+                    .controlSize(.small)
+                    .frame(width: 120)
+            } else if model.isWorking {
                 ProgressView()
                     .controlSize(.small)
             }

--- a/Tests/WorkshopWallpaperBridgeAppTests/AppViewModelTests.swift
+++ b/Tests/WorkshopWallpaperBridgeAppTests/AppViewModelTests.swift
@@ -5,7 +5,7 @@ import WorkshopWallpaperCore
 
 @MainActor
 final class AppViewModelTests: XCTestCase {
-    func testImportSelectedImportsMultipleScannedAssets() throws {
+    func testImportSelectedImportsMultipleScannedAssets() async throws {
         // Given
         let sourceRoot = try makeTempDirectory()
         let first = try makeScannedProject(root: sourceRoot, id: "first", title: "First Loop")
@@ -19,9 +19,13 @@ final class AppViewModelTests: XCTestCase {
         model.scannedAssets = [first, second]
         model.selectScannedAssets([first.id, second.id])
 
-        // When
-        model.importSelected()
+        // When (import runs off the main thread; await its completion)
+        await model.importSelected().value
         let manifest = try store.load()
+
+        // Then the working/progress state is cleared once the import finishes.
+        XCTAssertFalse(model.isWorking)
+        XCTAssertNil(model.importProgress)
 
         // Then
         XCTAssertEqual(Set(manifest.assets.map(\.id)), [first.id, second.id])


### PR DESCRIPTION
## Summary

- Builds on PR #39 and keeps import file copying off the main actor.
- Blocks overlapping library mutations while an import, manual video add, remove, or conversion is already running.
- Disables Add Video File and Remove while the shared library operation state is active.
- Adds AppViewModel regression coverage for no-op behavior during an active library operation.

## Validation

- [x] `git diff --check`
- [ ] `swift test` (not available on this Ubuntu/headless runner; PR #39 macOS CI is green, this PR should run the same Swift tests)

## Safety Checklist

- [x] This does not download Steam Workshop items.
- [x] This does not bypass Steam authentication or DRM.
- [x] This does not upload or redistribute creator assets.
- [x] File writes stay inside the app library or another explicit user-selected destination.
- [x] Async work cannot overlap in a way that corrupts the library manifest or stale UI state.
- [x] User-facing docs were updated in both English and Korean when needed. (No user-facing behavior docs changed.)

Related: #39